### PR TITLE
Add uaa-kube-config pipeline

### DIFF
--- a/uaa-kube-config/tasks/kube-dist.sh
+++ b/uaa-kube-config/tasks/kube-dist.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+export PATH=$PATH:/opt/rubies/ruby-2.3.1/bin
+
+gem install bosh_cli --no-ri --no-rdoc
+
+tar xf s3.fissile-binary/fissile-* -C /usr/local/bin fissile
+
+cd src
+source .envrc
+
+make releases kube-configs package-kube
+
+mv uaa-kube-*.zip ../out/

--- a/uaa-kube-config/tasks/kube-dist.yml
+++ b/uaa-kube-config/tasks/kube-dist.yml
@@ -1,0 +1,14 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: splatform/cf-ci
+inputs:
+- name: src
+- name: ci
+- name: s3.fissile-binary
+outputs:
+- name: out
+run:
+  path: ci/uaa-kube-config/tasks/kube-dist.sh

--- a/uaa-kube-config/uaa-kube-config.yml
+++ b/uaa-kube-config/uaa-kube-config.yml
@@ -1,0 +1,59 @@
+groups: []
+
+resources:
+- name: src
+  type: git
+  source:
+    branch: master
+    private_key: {{github-private-key}}
+    uri: git@github.com:hpcloud/uaa-fissile-release.git
+
+- name: ci
+  type: git
+  source:
+    uri: https://github.com/SUSE/cf-ci.git
+    branch: master
+    paths:
+    - uaa-kube-config/*
+
+- name: s3.fissile-binary
+  type: s3
+  source:
+    access_key_id: {{s3-access-key}}
+    endpoint: {{s3-endpoint}}
+    secret_access_key: {{s3-secret-key}}
+    bucket: fissile
+    regexp: fissile-(.*)\.g.*linux.amd64\.tgz
+    private: true
+
+- name: s3.artifact
+  type: s3
+  source:
+    access_key_id: {{s3-access-key}}
+    bucket: kube-config
+    endpoint: {{s3-endpoint}}
+    regexp: uaa-kube-(.*).zip$
+    secret_access_key: {{s3-secret-key}}
+    private: true
+
+jobs:
+- name: kube-dist
+  plan:
+  - aggregate:
+    - get: src
+      trigger: true
+
+    - get: ci
+      trigger: true
+
+    - get: s3.fissile-binary
+      trigger: true
+
+  - task: kube-dist
+    file: ci/uaa-kube-config/tasks/kube-dist.yml
+    privileged: true
+
+  - put: s3.artifact
+    params:
+      file: out/uaa-kube-*.zip
+      acl: public-read


### PR DESCRIPTION
This adds a UAA release generator pipeline.

To test, you should use the corresponding branch from https://github.com/hpcloud/uaa-fissile-release/pull/11 