### PR TITLE
fix k8s check script

### DIFF
--- a/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
+++ b/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
@@ -40,8 +40,8 @@ status "kube-dns should shows 4/4 ready"
 
 # ntp is installed and running
 
-systemctl is-active ntpd >& /dev/null
-status "ntp must be installed and active"
+systemctl is-active ntpd >& /dev/null || systemctl is-active systemd-timesyncd >& /dev/null
+status "ntp or systemd-timesyncd must be installed and active"
 
 # "persistent" storage class exists in K8s
 

--- a/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
+++ b/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
@@ -34,8 +34,7 @@ status "docker info should show overlay2"
 
 # kube-dns shows 4/4 ready
 
-kube_dns=$(kubectl get pods --all-namespaces | grep "kube-dns-")
-[[ $kube_dns =~ 4/4\ *Running ]]
+kubectl get pods --namespace=kube-system --selector k8s-app=kube-dns | grep -Eq '([0-9])/\1 *Running'
 status "kube-dns should shows 4/4 ready"
 
 # ntp is installed and running
@@ -60,7 +59,7 @@ status "Privileged must be enabled in 'kubelet'"
 
 # dns check for the current hostname resolution
 
-IP=$(nslookup $SCF_DOMAIN | grep answer: -A 2 | grep Address: | sed 's/Address: *//g')
+IP=$(host -tA "${SCF_DOMAIN}" | awk '{ print $NF }')
 /sbin/ifconfig | grep -wq "inet addr:$IP"
 status "dns check"
 


### PR DESCRIPTION
fix dns check, fix kube-dns check, remove grep for type or kind on persistent storage class check, script can now wither take domain name from env variables or can use the default cf-dev.io