### PR TITLE
Provosion CI K8S host with vagrantbox

### DIFF
--- a/kube-kvm/README.md
+++ b/kube-kvm/README.md
@@ -41,7 +41,7 @@ should also run on other KVM hosts which meet the following requirements, though
 testing has been done:
 - This script should be used on a KVM host with libvirt installed
 - The qemu user should have access to the path which the disk images will be stored in.
-  This is set by `KUBE_VM_IMAGE_PATH` (defaults to `~/qcow2-disks`)
+  This is set by `KUBE_VM_IMAGE_PATH` (defaults to `/var/lib/libvirt/images/`)
 - The default network defined in `net-default.xml` should be created and started:
   - `virsh net-define net-default.xml`
   - `virsh net-start default`
@@ -65,7 +65,7 @@ Other variables which can be set to modify the behaviour of the deployment scrip
 ```
 KUBE_VM_IMAGE_NAME # The name of the image in s3 to use. Defaults to the latest VM image
 KUBE_VM_IMAGE_PATH # The path to use for storing images, VM disks, and the vm key
-                   # This defaults to $HOME/qcow2-disks
+                   # This defaults to /var/lib/libvirt/images
 KUBE_VM_MEM_GIB    # The memory to allocate to the VM. Defaults to 8GiB
 ```
 

--- a/kube-kvm/README.md
+++ b/kube-kvm/README.md
@@ -1,0 +1,111 @@
+# Provisioning a Kubernetes host on KVM, without vagrant
+
+# Table of Contents
+
+  * [Overview](#overview)
+    * [Why not always use Vagrant?](#why-not-always-use-vagrant)
+  * [How to use this script](#how-to-use-this-script)
+    * [Prerequisites](#prerequisites)
+    * [Configuration](#configuration)
+    * [Deployment](#deployment)
+  * [How to use the VM](#how-to-use-the-vm)
+    * [Installing Dev Tools](#installing-dev-tools)
+
+
+# Overview
+
+This script provides a general-purpose Kubernetes host, with kube-dns and helm deployed,
+which is hospitable for SCF deployment
+
+## Why Not Always Use Vagrant?
+
+To be clear, the KVM image used by this deployment method is *packaged as a vagrant box* by
+the packer vagrant post-provisioner. Even though the input is a vagrant box, using vagrant
+to deploy it introduces a limitation of only being able to deploy one VM at a time on a
+given KVM host. In order to fully utilize shared KVM hosts for development and testing, as
+well as provide Kubernetes host pools for our CI systems, it is advantageous to have a way
+to deploy a VM from the generated KVM image without using Vagrant.
+
+It's important to be aware that the base image built by packer is intended to be a generic
+kube host, and doesn't have direnv, fissile, or stampy. The script in scf
+`bin/dev/install_tools.sh` can be run to install these tools, necessary for building
+releases, images, and charts used for deploying SCF in development. SCF can also be
+deployed from our chart bundle distributions, which use images on our docker hub.
+
+# How to Use This Script
+
+## Prerequisites
+
+This script is intended to be run on a SLES box which has been installed as a KVM host. It
+should also run on other KVM hosts which meet the following requirements, though limited
+testing has been done:
+- The `libvirt` user should be a member of the `root` group: `usermod -aG libvirt root`
+- The default network defined in `net-default.xml` should be created and started:
+  - `virsh net-define net-default.xml`
+  - `virsh net-start default`
+- The ntp service should be installed, synced, and started
+  - `sudo systemctl stop ntpd` (if already started)
+  - `sudo ntpdate time.nist.gov`
+  - `sudo systemctl enable ntpd`
+  - `sudo systemctl start ntpd`
+- The KVM host machine should have internet access through a Linux host bridge device named
+  `br0`. This is the default configuration when installing SLES as a KVM host. If using
+  Wicked as your network manager, you can follow the instructions in step 4 of
+  https://github.com/suse/scf#deploying to configure this bridge interface.
+
+## Configuration
+
+The `provision-kube-host-kvm.sh` script takes one argument, the name to use for the
+deployed Kubernetes host VM. This may alternatively be configured by setting the
+`KUBE_VM_NAME` environment variable.
+
+#### WARNING:
+```
+If a VM with the name passed via the name argument already exists, it will be deleted!
+```
+
+Other variables which can be set to modify the behaviour of the deployment scripts are:
+
+```
+KUBE_VM_IMAGE_NAME # The name of the image in s3 to use. Defaults to the latest VM image
+KUBE_VM_IMAGE_PATH # The path to use for storing images, VM disks, and the vm key
+                   # This defaults to $HOME/qcow2-disks
+KUBE_VM_MEM_GIB    # The memory to allocate to the VM. Defaults to 8GiB
+```
+
+## Deployment
+
+To deploy a new VM, run `./provision-kube-host-kvm.sh <vm-name>`. See the above Warning
+
+# How to Use the VM
+
+Once the deployment of your VM is finished, the provisioning script will output information
+about how to set your kubernetes config to access the VM, which will look like:
+
+```
+kubectl config set-cluster --server=10.9.169.158:8080 my_vm
+kubectl config set-context my_vm --cluster=my_vm
+kubectl config use-context my_vm
+```
+
+You can also access the VM via ssh using the password `vagrant` for `vagrant@$IP`, or the
+default vagrant VM access key which is downloaded as part of the provisioning to
+`"${KUBE_VM_IMAGE_PATH}/vm-key"`
+
+## Installing Dev Tools
+
+When deploying a Kubernetes host with the provisioning script, direnv and the dev tools are
+not installed. Should you wish to prepare the VM so that you can run `make vagrant-prep`,
+you will need to run the following as the `vagrant` user:
+
+```
+mkdir -p /home/vagrant/bin
+wget -O /home/vagrant/bin/direnv --no-verbose \
+  https://github.com/direnv/direnv/releases/download/v2.11.3/direnv.linux-amd64
+chmod a+x /home/vagrant/bin/direnv
+echo 'eval "$(/home/vagrant/bin/direnv hook bash)"' >> ${HOME}/.bashrc
+ln -s /home/vagrant/scf/bin/dev/vagrant-envrc ${HOME}/.envrc
+/home/vagrant/bin/direnv allow ${HOME}
+/home/vagrant/bin/direnv allow ${HOME}/scf
+sudo -E SCF_BIN_DIR=/usr/local/bin HOME=/home/vagrant /home/vagrant/bin/direnv exec /home/vagrant/scf/bin/dev/install_tools.sh
+```

--- a/kube-kvm/README.md
+++ b/kube-kvm/README.md
@@ -43,11 +43,7 @@ testing has been done:
 - The default network defined in `net-default.xml` should be created and started:
   - `virsh net-define net-default.xml`
   - `virsh net-start default`
-- The ntp service should be installed, synced, and started
-  - `sudo systemctl stop ntpd` (if already started)
-  - `sudo ntpdate time.nist.gov`
-  - `sudo systemctl enable ntpd`
-  - `sudo systemctl start ntpd`
+- A system time service (ntp or timedatectl) should be installed, synced, and started
 - The KVM host machine should have internet access through a Linux host bridge device named
   `br0`. This is the default configuration when installing SLES as a KVM host. If using
   Wicked as your network manager, you can follow the instructions in step 4 of
@@ -60,9 +56,7 @@ deployed Kubernetes host VM. This may alternatively be configured by setting the
 `KUBE_VM_NAME` environment variable.
 
 #### WARNING:
-```
-If a VM with the name passed via the name argument already exists, it will be deleted!
-```
+_**If a VM with the name passed via the name argument already exists, it will be deleted!**_
 
 Other variables which can be set to modify the behaviour of the deployment scripts are:
 
@@ -75,7 +69,8 @@ KUBE_VM_MEM_GIB    # The memory to allocate to the VM. Defaults to 8GiB
 
 ## Deployment
 
-To deploy a new VM, run `./provision-kube-host-kvm.sh <vm-name>`. See the above Warning
+To deploy a new VM, run `./provision-kube-host-kvm.sh <vm-name>`. See the above
+[warning](#warning)
 
 # How to Use the VM
 
@@ -83,7 +78,7 @@ Once the deployment of your VM is finished, the provisioning script will output 
 about how to set your kubernetes config to access the VM, which will look like:
 
 ```
-kubectl config set-cluster --server=10.9.169.158:8080 my_vm
+kubectl config set-cluster --server=${IP}:8080 my_vm
 kubectl config set-context my_vm --cluster=my_vm
 kubectl config use-context my_vm
 ```

--- a/kube-kvm/README.md
+++ b/kube-kvm/README.md
@@ -39,7 +39,9 @@ deployed from our chart bundle distributions, which use images on our docker hub
 This script is intended to be run on a SLES box which has been installed as a KVM host. It
 should also run on other KVM hosts which meet the following requirements, though limited
 testing has been done:
-- The `libvirt` user should be a member of the `root` group: `usermod -aG libvirt root`
+- This script should be used on a KVM host with libvirt installed
+- The qemu user should have access to the path which the disk images will be stored in.
+  This is set by `KUBE_VM_IMAGE_PATH` (defaults to `~/qcow2-disks`)
 - The default network defined in `net-default.xml` should be created and started:
   - `virsh net-define net-default.xml`
   - `virsh net-start default`

--- a/kube-kvm/net-default.xml
+++ b/kube-kvm/net-default.xml
@@ -1,0 +1,10 @@
+<network connections='1'>
+  <name>default</name>
+  <forward mode='nat'/>
+  <bridge name='virbr0'/>
+  <ip address='192.168.122.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.122.2' end='192.168.122.254'/>
+    </dhcp>
+  </ip>
+</network>

--- a/kube-kvm/provision-kube-host-kvm.sh
+++ b/kube-kvm/provision-kube-host-kvm.sh
@@ -13,7 +13,7 @@
 set -o errexit
 
 export KUBE_VM_NAME=${KUBE_VM_NAME:-$1}
-export KUBE_VM_IMAGE_NAME=${KUBE_VM_IMAGE_NAME:-scf-libvirt-v2.0.6}
+export KUBE_VM_IMAGE_NAME=${KUBE_VM_IMAGE_NAME:-scf-libvirt-v2.0.7}
 export KUBE_VM_IMAGE_PATH=${KUBE_VM_IMAGE_PATH:-~/qcow2-disks}
 export KUBE_VM_MEM_GIB=${KUBE_VM_MEM_GIB:-8}
 

--- a/kube-kvm/provision-kube-host-kvm.sh
+++ b/kube-kvm/provision-kube-host-kvm.sh
@@ -17,53 +17,54 @@ export KUBE_VM_IMAGE_NAME=${KUBE_VM_IMAGE_NAME:-scf-libvirt-v2.0.7}
 export KUBE_VM_IMAGE_PATH=${KUBE_VM_IMAGE_PATH:-~/qcow2-disks}
 export KUBE_VM_MEM_GIB=${KUBE_VM_MEM_GIB:-8}
 
-mkdir -p "$KUBE_VM_IMAGE_PATH"
-cd "$KUBE_VM_IMAGE_PATH"
-
-if [[ -z "$KUBE_VM_NAME" ]]; then
+if [[ -z "${KUBE_VM_NAME}" ]]; then
   echo "A VM name must be provided"
   exit 1
 fi
 
+mkdir -p "${KUBE_VM_IMAGE_PATH}"
+cd "${KUBE_VM_IMAGE_PATH}"
+
 # Fetch base image if it doesn't exist
-if [[ ! -f $KUBE_VM_IMAGE_NAME.qcow2 ]]; then
+if [[ ! -f "${KUBE_VM_IMAGE_NAME}.qcow2" ]]; then
   echo "Fetching base image:"
-  curl -L https://cf-opensusefs2.s3.amazonaws.com/vagrant/${KUBE_VM_IMAGE_NAME}.box | tar --wildcards box.img -xz
-  mv box.img $KUBE_VM_IMAGE_NAME.qcow2
+  curl -L "https://cf-opensusefs2.s3.amazonaws.com/vagrant/${KUBE_VM_IMAGE_NAME}.box" | tar -xz box.img
+  mv box.img "${KUBE_VM_IMAGE_NAME}.qcow2"
 fi
 
 # Fetch VM access key if it doesn't exist
-if [[ ! -f vm-key ]]; then
-  curl -sL -o "vm-key" https://raw.githubusercontent.com/mitchellh/vagrant/v1.9.6/keys/vagrant
+KUBE_VM_KEY=${KUBE_VM_KEY:-$PWD/vm-key}
+if [[ ! -f "${KUBE_VM_KEY}" ]] && [[ "${KUBE_VM_KEY}" == "$PWD/vm-key" ]]; then
+  curl -sL -o "{KUBE_VM_KEY}" https://raw.githubusercontent.com/mitchellh/vagrant/v1.9.6/keys/vagrant
   chmod 400 vm-key
 fi
-KUBE_VM_KEY=${KUBE_VM_KEY:-$PWD/vm-key}
 
-if [[ $KUBE_VM_MEM_GIB -gt $(free -g | awk 'NR == 2 { print $2 - 2 }') ]]; then
-  echo KUBE_VM_MEM_GIB value $KUBE_VM_MEM_GIB exceeds system resources
+# Check that provisioning the VM would leave host machine with at least 2 GiB for OS/KVM overhead
+if [[ ${KUBE_VM_MEM_GIB} -gt $(free -g | awk 'NR == 2 { print $2 - 2 }') ]]; then
+  echo "KUBE_VM_MEM_GIB value ${KUBE_VM_MEM_GIB} exceeds system resources"
   exit 1
 fi
 
 unset RUNNING_VM_IMAGE
-if virsh domstate $KUBE_VM_NAME 2>/dev/null; then
-  echo "Deleting existing domain $KUBE_VM_NAME"
-  RUNNING_VM_IMAGE=$(virsh dumpxml $KUBE_VM_NAME | grep 'source file' | grep -o "'.*'" | tr -d "'")
-  if [[ -z $RUNNING_VM_IMAGE ]]; then
-    echo "Disk for domain $KUBE_VM_NAME could not be determined. Please delete this domain manually"
+if virsh domstate "${KUBE_VM_NAME}" 2>/dev/null; then
+  echo "Deleting existing domain ${KUBE_VM_NAME}"
+  RUNNING_VM_IMAGE=$(virsh dumpxml "${KUBE_VM_NAME}" | grep 'source file' | grep -o "'.*'" | tr -d "'")
+  if [[ -z "${RUNNING_VM_IMAGE}" ]]; then
+    echo "Disk for domain ${KUBE_VM_NAME} could not be determined. Please delete this domain manually"
     exit 1
   fi
-  virsh destroy "$KUBE_VM_NAME"
-  virsh undefine "$KUBE_VM_NAME"
-  rm -f "$RUNNING_VM_IMAGE"
+  virsh destroy "${KUBE_VM_NAME}"
+  virsh undefine "${KUBE_VM_NAME}"
+  rm -f "${RUNNING_VM_IMAGE}"
 fi
 
-cp --reflink=auto "$KUBE_VM_IMAGE_NAME.qcow2" "$KUBE_VM_IMAGE_NAME-$KUBE_VM_NAME.qcow2"
+qemu-img create -f qcow2 -b "${KUBE_VM_IMAGE_NAME}.qcow2" "${KUBE_VM_IMAGE_NAME}-${KUBE_VM_NAME}.qcow2"
 # TODO: Test if virbr0 is present
 virt-install \
-  --name "$KUBE_VM_NAME" \
-  --memory $(( KUBE_VM_MEM_GIB * 1024 )) \
+  --name "${KUBE_VM_NAME}" \
+  --memory "$(( KUBE_VM_MEM_GIB * 1024 ))" \
   --vcpus 1 \
-  --disk "$KUBE_VM_IMAGE_NAME-$KUBE_VM_NAME.qcow2" \
+  --disk "${KUBE_VM_IMAGE_NAME}-${KUBE_VM_NAME}.qcow2" \
   --import \
   --network network=default \
   --network bridge=br0 \
@@ -71,63 +72,63 @@ virt-install \
   --wait 0 \
   --hvm
 
-echo "Sleeping 30 seconds to allow VM to start and obtain IP"
-sleep 30
 IP_WAIT_TIMEOUT=600
 unset KUBE_VM_DEFAULT_MAC
-while [[ -z "$KUBE_VM_DEFAULT_MAC" ]]; do
-  echo "Checking if default interface has MAC address"
-  KUBE_VM_DEFAULT_MAC=$(virsh domiflist "$KUBE_VM_NAME" | grep default | grep -oE '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}') || true
-  if [[ -z "$KUBE_VM_DEFAULT_MAC" ]]; then
-    if [[ $IP_WAIT_TIMEOUT -ge 0 ]]; then
+echo "Waiting 15 seconds for default interface to receive a MAC address"
+while [[ -z "${KUBE_VM_DEFAULT_MAC}" ]]; do
+  sleep 15
+  KUBE_VM_DEFAULT_MAC=$(virsh domiflist "${KUBE_VM_NAME}" | grep default | grep -oE '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}') || true
+  if [[ -z "${KUBE_VM_DEFAULT_MAC}" ]]; then
+    if [[ ${IP_WAIT_TIMEOUT} -ge 0 ]]; then
       (( IP_WAIT_TIMEOUT -= 15 ))
       echo "MAC address not yet available. Retrying in 15 seconds"
-      sleep 15
     else
-      echo "No MAC address for default interface on VM $KUBE_VM_NAME after 10 minutes. Check output of \`sudo virsh domiflist $KUBE_VM_NAME\`"
+      echo "No MAC address for default interface on VM ${KUBE_VM_NAME} after 10 minutes. Check output of \`sudo virsh domiflist ${KUBE_VM_NAME}\`"
       exit 1
     fi
   fi
 done
 unset KUBE_VM_DEFAULT_IP
-while [[ -z "$KUBE_VM_DEFAULT_IP" ]]; do
-  echo "Checking if IP lease exists for interface $KUBE_VM_DEFAULT_MAC"
-  KUBE_VM_DEFAULT_IP=$(virsh net-dhcp-leases default --mac "$KUBE_VM_DEFAULT_MAC" | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}') || true
-  if [[ -z "$KUBE_VM_DEFAULT_IP" ]]; then
-    if [[ $IP_WAIT_TIMEOUT -ge 0 ]]; then
+while [[ -z "${KUBE_VM_DEFAULT_IP}" ]]; do
+  echo "Checking if IP lease exists for interface ${KUBE_VM_DEFAULT_MAC}"
+  KUBE_VM_DEFAULT_IP=$(virsh net-dhcp-leases default --mac "${KUBE_VM_DEFAULT_MAC}" | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}') || true
+  if [[ -z "${KUBE_VM_DEFAULT_IP}" ]]; then
+    if [[ ${IP_WAIT_TIMEOUT} -ge 0 ]]; then
       (( IP_WAIT_TIMEOUT -= 15 ))
-      echo "No IP assigned for $KUBE_VM_DEFAULT_MAC. Retrying in 15 seconds"
+      echo "No IP assigned for ${KUBE_VM_DEFAULT_MAC}. Retrying in 15 seconds"
       sleep 15
     else
-      echo "No IP assigned for $KUBE_VM_DEFAULT_MAC after 10 minutes. Exiting."
+      echo "No IP assigned for ${KUBE_VM_DEFAULT_MAC} after 10 minutes. Exiting."
       exit 1
     fi
   fi
 done
-echo "Docker VM IP found: $KUBE_VM_DEFAULT_IP. Waiting for sshd to start"
+echo "Docker VM IP found: ${KUBE_VM_DEFAULT_IP}. Waiting for sshd to start"
 SSHD_TIMEOUT=60
-while [[ $SSHD_TIMEOUT -ge 0 ]]; do
-  nc $KUBE_VM_DEFAULT_IP 22 </dev/null | grep 'SSH-' && break
+while [[ ${SSHD_TIMEOUT} -ge 0 ]]; do
+  nc "${KUBE_VM_DEFAULT_IP}" 22 </dev/null | grep 'SSH-' && break
   sleep 5
   (( SSHD_TIMEOUT -= 5 ))
 done
-ssh-keygen -R $KUBE_VM_DEFAULT_IP
-ssh -o StrictHostKeyChecking=no -Ti "$KUBE_VM_KEY" vagrant@$KUBE_VM_DEFAULT_IP -- sudo bash -o errexit << EOF
+ssh-keygen -R "${KUBE_VM_DEFAULT_IP}"
+
+ssh -o StrictHostKeyChecking=no -Ti "${KUBE_VM_KEY}" vagrant@${KUBE_VM_DEFAULT_IP} -- sudo bash -o errexit << EOF
 hostname $KUBE_VM_NAME
 echo $KUBE_VM_NAME > /etc/hostname
 cp /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-eth1
-echo DHCLIENT_SET_DEFAULT_ROUTE='yes' /etc/sysconfig/network/ifcfg-eth1
-wicked ifup eth1
+echo DHCLIENT_SET_DEFAULT_ROUTE='no' >> /etc/sysconfig/network/ifcfg-eth0
+echo DHCLIENT_SET_DEFAULT_ROUTE='yes' >> /etc/sysconfig/network/ifcfg-eth1
+systemctl restart network
 EOF
 
-KUBE_VM_BRIDGED_IP=$(ssh -i "$KUBE_VM_KEY" vagrant@$KUBE_VM_DEFAULT_IP 'ip -4 addr show eth1' | tr / ' ' | awk '/inet/ { print $2 }')
-if [[ -z "$KUBE_VM_BRIDGED_IP" ]]; then
-  echo "There was a problem getting the IP of the bridged interface. See output of \`ifconfig eth1\` in VM $KUBE_VM_NAME"
+KUBE_VM_BRIDGED_IP=$(ssh -i "${KUBE_VM_KEY}" vagrant@"${KUBE_VM_DEFAULT_IP}" 'ip -4 addr show eth1' | tr / ' ' | awk '/inet/ { print $2 }')
+if [[ -z "${KUBE_VM_BRIDGED_IP}" ]]; then
+  echo "There was a problem getting the IP of the bridged interface. See output of \`ifconfig eth1\` in VM ${KUBE_VM_NAME}"
   exit 1
 fi
 
-ssh-keygen -R $KUBE_VM_BRIDGED_IP
-ssh -o StrictHostKeyChecking=no -Ti "$KUBE_VM_KEY" vagrant@$KUBE_VM_BRIDGED_IP  << EOF
+ssh-keygen -R "${KUBE_VM_BRIDGED_IP}"
+ssh -o StrictHostKeyChecking=no -Ti "${KUBE_VM_KEY}" vagrant@"${KUBE_VM_BRIDGED_IP}"  << EOF
 git clone https://github.com/suse/scf
 cd scf
 sudo bash -o errexit << EOSU
@@ -141,7 +142,7 @@ Kube deployment completed successfully!
 
 -----------------------------------------------------------------------------------------------------------------------------------------------------
 # Run the following commands in an environment with kubectl to target this kube cluster:
-kubectl config set-cluster --server=$KUBE_VM_BRIDGED_IP:8080 $KUBE_VM_NAME
-kubectl config set-context $KUBE_VM_NAME --cluster=$KUBE_VM_NAME
-kubectl config use-context $KUBE_VM_NAME
+kubectl config set-cluster --server=${KUBE_VM_BRIDGED_IP}:8080 ${KUBE_VM_NAME}
+kubectl config set-context ${KUBE_VM_NAME} --cluster=${KUBE_VM_NAME}
+kubectl config use-context ${KUBE_VM_NAME}
 EOF

--- a/kube-kvm/provision-kube-host-kvm.sh
+++ b/kube-kvm/provision-kube-host-kvm.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+# This script is intended to be run on a SLES box installed as a KVM host.
+# After OS installation, the following commands should also be run to set up directory permissions and the default network (as root):
+# usermod -aG libvirt root
+# virsh net-define net-default.xml
+# virsh net-start default
+# ntpdate time.nist.gov
+# systemctl enable ntpd
+# systemctl start ntpd
+
+set -o errexit
+
+export KUBE_VM_NAME=${KUBE_VM_NAME:-$1}
+export KUBE_VM_IMAGE_NAME=${KUBE_VM_IMAGE_NAME:-scf-libvirt-v2.0.6}
+export KUBE_VM_IMAGE_PATH=${KUBE_VM_IMAGE_PATH:-~/qcow2-disks}
+export KUBE_VM_MEM_GIB=${KUBE_VM_MEM_GIB:-8}
+
+# Used for displaying external setup information at end of provisioning
+export OBJECT_STORAGE_BASE_URL=${OBJECT_STORAGE_BASE_URL:-\${OBJECT_STORAGE_BASE_URL}}
+export OBJECT_STORAGE_YAML_BUCKET=${OBJECT_STORAGE_YAML_BUCKET:-kube-config}
+
+mkdir -p "$KUBE_VM_IMAGE_PATH"
+cd "$KUBE_VM_IMAGE_PATH"
+
+if [[ -z $KUBE_VM_NAME ]]; then
+  echo "A VM name must be provided"
+  exit 1
+fi
+
+# Fetch base image if it doesn't exist
+if [[ ! -f $KUBE_VM_IMAGE_NAME.qcow2 ]]; then
+  echo "Fetching base image:"
+  curl -L https://cf-opensusefs2.s3.amazonaws.com/vagrant/${KUBE_VM_IMAGE_NAME}.box | tar --wildcards box.img -xz
+  mv box.img $KUBE_VM_IMAGE_NAME.qcow2
+fi
+
+# Fetch VM access key if it doesn't exist
+if [[ ! -f vm-key ]]; then
+  curl -sL -o "vm-key" https://raw.githubusercontent.com/mitchellh/vagrant/v1.9.6/keys/vagrant
+  chmod 400 vm-key
+fi
+KUBE_VM_KEY=${KUBE_VM_KEY:-$PWD/vm-key} 
+
+if [[ $KUBE_VM_MEM_GIB -gt $(( $(free -g | grep [0-9] | head -1 | awk '{print $2}') - 2 )) ]]; then
+  echo KUBE_VM_MEM_GIB value $KUBE_VM_MEM_GIB exceeds system resources
+  exit 1
+fi
+
+unset RUNNING_VM_IMAGE
+if virsh domstate $KUBE_VM_NAME 2>/dev/null; then
+  echo "Deleting existing domain $KUBE_VM_NAME"
+  RUNNING_VM_IMAGE=$(virsh dumpxml $KUBE_VM_NAME | grep 'source file' | grep -o "'.*'" | tr -d "'")
+  if [[ -z $RUNNING_VM_IMAGE ]]; then
+    echo "Disk for domain $KUBE_VM_NAME could not be determined. Please delete this domain manually"
+    exit 1
+  fi
+  virsh destroy "$KUBE_VM_NAME"
+  virsh undefine "$KUBE_VM_NAME"
+  rm -f "$RUNNING_VM_IMAGE"
+fi
+
+cp "$KUBE_VM_IMAGE_NAME.qcow2" "$KUBE_VM_IMAGE_NAME-$KUBE_VM_NAME.qcow2"
+# TODO: Test if virbr0 is present
+virt-install \
+  --name "$KUBE_VM_NAME" \
+  --memory $(( KUBE_VM_MEM_GIB * 1024 )) \
+  --vcpus 1 \
+  --disk "$KUBE_VM_IMAGE_NAME-$KUBE_VM_NAME.qcow2" \
+  --import \
+  --network network=default \
+  --network bridge=br0 \
+  --os-variant opensuse42.2 \
+  --wait 0 \
+  --hvm
+
+echo "Sleeping 30 seconds to allow VM to start and obtain IP"
+sleep 30 
+unset KUBE_VM_DEFAULT_IP
+# TODO: Clean up variable assignment (timeouts)
+IP_WAIT_TIMEOUT=150
+KUBE_VM_DEFAULT_MAC=$(virsh domiflist "$KUBE_VM_NAME" | grep default | grep -oE '([[:xdigit:]]{2}:){5}[[:xdigit:]]{2}') || true
+if [[ -z $KUBE_VM_DEFAULT_MAC ]]; then
+  echo "No MAC address for default interface on VM $KUBE_VM_NAME. Check output of \`sudo virsh domiflist $KUBE_VM_NAME\`"
+  exit 1
+fi
+while [[ -z $KUBE_VM_DEFAULT_IP ]]; do
+  echo "Checking if IP lease exists for interface $KUBE_VM_DEFAULT_MAC"
+  KUBE_VM_DEFAULT_IP=$(virsh net-dhcp-leases default | grep "$KUBE_VM_DEFAULT_MAC" | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}') || true
+  if [[ -z $KUBE_VM_DEFAULT_IP ]]; then
+    if [[ $IP_WAIT_TIMEOUT -ge 0 ]]; then
+      (( IP_WAIT_TIMEOUT -= 15 ))
+      echo "No IP assigned for $KUBE_VM_DEFAULT_MAC. Retrying in 15 seconds"
+      sleep 15
+    else
+      echo "No IP assigned for $KUBE_VM_DEFAULT_MAC after 3 minutes. Exiting."
+      exit 1
+    fi
+  fi
+done
+echo "Docker VM IP found: $KUBE_VM_DEFAULT_IP. Waiting for sshd to start"
+SSHD_TIMEOUT=60
+while [[ $SSHD_TIMEOUT -ge 0 ]]; do
+  echo '' | nc $KUBE_VM_DEFAULT_IP 22 | grep -i ssh && break
+  sleep 5
+  (( SSHD_TIMEOUT -= 5 ))
+done
+ssh-keygen -R $KUBE_VM_DEFAULT_IP
+ssh -o StrictHostKeyChecking=no -Ti "$KUBE_VM_KEY" vagrant@$KUBE_VM_DEFAULT_IP << EOF
+sudo bash -o errexit << EOSU
+hostname $KUBE_VM_NAME
+echo $KUBE_VM_NAME > /etc/hostname
+cp /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-eth1
+echo DHCLIENT_SET_DEFAULT_ROUTE='yes' /etc/sysconfig/network/ifcfg-eth1
+wicked ifup eth1
+EOSU
+EOF
+
+echo "Sleeping 15 seconds for bridged interface to obtain IP"
+sleep 15
+KUBE_VM_BRIDGED_IP=$(ssh -i "$KUBE_VM_KEY" vagrant@$KUBE_VM_DEFAULT_IP '/sbin/ifconfig eth1' | grep -oE 'addr:10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | sed 's/addr://g')
+if [[ -z $KUBE_VM_BRIDGED_IP ]]; then
+  echo "There was a problem getting the IP of the bridged interface. See output of \`ifconfig eth1\` in VM $KUBE_VM_NAME"
+  exit 1
+fi
+
+ssh-keygen -R $KUBE_VM_BRIDGED_IP
+ssh -o StrictHostKeyChecking=no -Ti "$KUBE_VM_KEY" vagrant@$KUBE_VM_BRIDGED_IP  << EOF
+git clone https://github.com/suse/scf
+cd scf
+sudo bash -o errexit << EOSU
+export SCF_BIN_DIR=/usr/local/bin
+./bin/common/install_tools.sh
+EOSU
+EOF
+
+cat << EOF
+Kube deployment completed successfully!
+
+-----------------------------------------------------------------------------------------------------------------------------------------------------
+# Run the following commands in an environment with kubectl to target this kube cluster:
+kubectl config set-cluster --server=$KUBE_VM_BRIDGED_IP:8080 $KUBE_VM_NAME
+kubectl config set-context $KUBE_VM_NAME --cluster=$KUBE_VM_NAME
+kubectl config use-context $KUBE_VM_NAME
+EOF

--- a/kube-kvm/provision-kube-host-kvm.sh
+++ b/kube-kvm/provision-kube-host-kvm.sh
@@ -14,7 +14,7 @@ set -o errexit
 
 export KUBE_VM_NAME=${1:-${KUBE_VM_NAME}}
 export KUBE_VM_IMAGE_NAME=${KUBE_VM_IMAGE_NAME:-scf-libvirt-v2.0.7}
-export KUBE_VM_IMAGE_PATH=${KUBE_VM_IMAGE_PATH:-~/qcow2-disks}
+export KUBE_VM_IMAGE_PATH=${KUBE_VM_IMAGE_PATH:-/var/lib/libvirt/images}
 export KUBE_VM_MEM_GIB=${KUBE_VM_MEM_GIB:-8}
 
 if [[ -z "${KUBE_VM_NAME}" ]]; then


### PR DESCRIPTION
This PR adds a provisioning script for our CI kubernetes hosts, which uses the same libvirt image as our vagrant deployment (without actually using vagrant)

NOTE: The URL for the vagrantbox will need to be updated once the work in SCF is merged