### PR TITLE
Split scf system checks into categories for different types of nodes

### DIFF
--- a/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
+++ b/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
@@ -1,5 +1,29 @@
 #!/bin/bash
 
+function usage() {
+    cat <<EOF
+Usage: $(basename "${0}") ?options? ?category?
+
+  -h: Displays this help message
+
+  Supported categories: all, api, kube, node
+  Defaults to: all
+EOF
+}
+
+while getopts "h" opt; do
+    case $opt in
+	h)
+	    usage
+	    exit
+	    ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+category="${1:-all}"
+
 #Script to determine is the K8s host is "ready" for cf deployment
 FAILED=0
 SCF_DOMAIN=${SCF_DOMAIN:-cf-dev.io}
@@ -28,6 +52,9 @@ function status() {
 	FAILED=1
     fi
 }
+
+
+echo "Testing $(green $category)"
 
 # cgroup memory & swap accounting in /proc/cmdline
 grep -wq "cgroup_enable=memory" /proc/cmdline

--- a/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
+++ b/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
@@ -4,7 +4,7 @@ function usage() {
     cat <<EOF
 Usage: $(basename "${0}") [options] [category]
 
-  -h: Displays this help message
+  -h, --help: Displays this help message
 
   Supported categories: all, api, kube, node
   Defaults to: all
@@ -23,6 +23,14 @@ done
 shift $((OPTIND-1))
 
 category="${1:-all}"
+case ${category} in
+    all|api|kube|node)
+	: # ok, nothing to do
+	;;
+    *) usage
+	exit 1
+	;;
+esac
 
 #Script to determine is the K8s host is "ready" for cf deployment
 FAILED=0

--- a/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
+++ b/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
@@ -2,24 +2,33 @@
 
 #Script to determine is the K8s host is "ready" for cf deployment
 FAILED=0
-
 SCF_DOMAIN=${SCF_DOMAIN:-cf-dev.io}
+
 function green() {
-  awk '{ print "\033[32mVerified: " $0 "\033[0m" }';
+    printf "\033[32m%b\033[0m\n" "$1"
 }
 
 function red() {
-  awk '{ print "\033[31mConfiguration problem detected: " $0 "\033[0m" }';
+    printf "\033[31m%b\033[0m\n" "$1"
+}
+
+function verified() {
+    green "Verified: $1"
+}
+
+function trouble() {
+    red "Configuration problem detected: $1"
 }
 
 function status() {
-  if [ $? -eq 0 ]; then
-    echo "$1" | green
-  else
-    echo "$1" | red
-    FAILED=1
-  fi
+    if [ $? -eq 0 ]; then
+	verified "$1"
+    else
+	trouble "$1"
+	FAILED=1
+    fi
 }
+
 # cgroup memory & swap accounting in /proc/cmdline
 grep -wq "cgroup_enable=memory" /proc/cmdline
 status "cgroup_enable memory"

--- a/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
+++ b/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
@@ -93,8 +93,8 @@ fi
 
 # "persistent" storage class exists in K8s
 if having_category all kube ; then
-    kubectl get storageclasses |& grep -wq "persistent"
-    status "'persistent' storage class should exist in K8s"
+    test $(kubectl get storageclasses |& wc -l) -gt 1
+    status "A storage class should exist in K8s"
 fi
 
 # privileged pods are enabled in K8s

--- a/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
+++ b/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
@@ -4,7 +4,7 @@ function usage() {
     cat <<EOF
 Usage: $(basename "${0}") [options] [category]
 
-  -h, --help: Displays this help message
+  -h: Displays this help message
 
   Supported categories: all, api, kube, node
   Defaults to: all

--- a/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
+++ b/cf-deploy-teardown/tasks/k8s-ready-state-check.sh
@@ -81,10 +81,8 @@ if having_category node ; then
 
     grep -wq "swapaccount=1" /proc/cmdline
     status "swapaccount enable"
-fi
 
-# docker info should show overlay2
-if having_category api kube node ; then
+    # docker info should show overlay2
     docker info 2> /dev/null | grep -wq "Storage Driver: overlay2"
     status "docker info should show overlay2"
 fi


### PR DESCRIPTION
In reverse order, top committed last
* Reworked check for storageclass to simply count instead of requiring a specific name. Requested by @aarondl 
*   Added helper for category testing, and annotated all checks with their categories.
*   Added usage information, option processing to invoke it, and category setup.
*   Separated colorization (`red`, `green`) from status types (`verified`, `trouble`).
     Replaced weird `awk`/`print` construction with bash `printf`.

