### PR TITLE
certstrap: stop linker from stripping symbol tables

### DIFF
--- a/certstrap/tasks/build.sh
+++ b/certstrap/tasks/build.sh
@@ -5,7 +5,7 @@ set -o errexit -o nounset -o xtrace
 export GOPATH=$PWD/go
 
 package="github.com/square/certstrap"
-go build -ldflags=-s "${package}"
+go build "${package}"
 version="$(git -C "${GOPATH}/src/${package}" describe --always)"
 tar czf "out/certstrap-${version}.tgz" \
     --numeric-owner \


### PR DESCRIPTION
Meant to leave -w in, but removed it instead.  Since -w appears to not gain us anything, just remove all of -ldflags entirely instead.