### PR TITLE
cf: use a custom pool resource that doesn't fail on reset

### DIFF
--- a/cf/scf-develop.yaml.erb
+++ b/cf/scf-develop.yaml.erb
@@ -182,6 +182,11 @@ resource_types:
     source:
         repository: mrsixw/concourse-rsync-resource
 
+  - name: pool
+    type: docker-image
+    source:
+      repository: mookas/pool-resource
+
 jobs:
   <% if manual_pull_sources %>
   - name: pull-sources


### PR DESCRIPTION
We were getting useless errors of the form:

```
acquiring lock on: scf-deploy
.......error acquiring lock: exit status 128
```

This was likely the `git fetch` failing; testing the theory.