### PR TITLE
cf: delete quotes in image names when running tests

### DIFF
--- a/cf/Jenkinsfile
+++ b/cf/Jenkinsfile
@@ -24,7 +24,7 @@ void runTest(String testName) {
 EOF
         }
 
-        image=\$(awk '\$1 == "image:" { print \$2 }' "kube/cf/bosh-task/${testName}.yaml")
+        image=\$(awk '\$1 == "image:" { print \$2 }' "kube/cf/bosh-task/${testName}.yaml" | tr -d '"')
 
         kubectl run \
             --namespace=${JOB_BASE_NAME}-${BUILD_NUMBER}-scf \


### PR DESCRIPTION
We now quote everything in fissile-generated kube configs; delete them when passing things to the command line.