### PR TITLE
fix image error from qa ci

### DIFF
--- a/helm-deploy-test/tasks/run-test.sh
+++ b/helm-deploy-test/tasks/run-test.sh
@@ -26,7 +26,7 @@ kube_overrides() {
 EOF
 }
 
-image=$(awk '$1 == "image:" { print $2 }' "s3.scf-config/kube/cf/bosh-task/${TEST_NAME}.yaml")
+image=$(awk '$1 == "image:" { gsub(/"/, "", $2); print $2 }' "s3.scf-config/kube/cf/bosh-task/${TEST_NAME}.yaml")
 kubectl run \
     --namespace="${CF_NAMESPACE}" \
     --attach \


### PR DESCRIPTION
https://trello.com/c/tMEVbcNs/398-qa-pipeline-image-error
new kube yamls puts "image" in double quotes which causes qa ci to break.
`kubectl run --namespace=scf --attach --restart=Never '--image="splatform/scf-smoke-tests:ebee4c130e2a29db34250dfe0101615c3b1abb9b"' '--overrides='

`error: Invalid image name "\"splatform/scf-smoke-tests:ebee4c130e2a29db34250dfe0101615c3b1abb9b\"": invalid reference format`
