### PR TITLE
Fix tcp routing in the Jenkinsfile as well. 

### DIFF
--- a/cf/Jenkinsfile
+++ b/cf/Jenkinsfile
@@ -16,7 +16,9 @@ void runTest(String testName) {
                 obj = YAML.load_file('\$1')
                 obj['spec']['containers'].each do |container|
                     container['env'].each do |env|
-                        value = env['name'] == 'DOMAIN' ? domain : env['value']
+                        value = env['value']
+                        value = domain          if env['name'] == 'DOMAIN'
+                        value = "tcp.#{domain}" if env['name'] == 'TCP_DOMAIN'
                         env['value'] = value.to_s
                     end
                 end


### PR DESCRIPTION
We have to set and override the `TCP_DOMAIN` too. That will become `properties.acceptance_tests_brain.tcp_domain`, will become `CF_TCP_DOMAIN` in the test-brain.