### PR TITLE
cf: Enable concurrent builds

### DIFF
--- a/cf/Jenkinsfile
+++ b/cf/Jenkinsfile
@@ -42,7 +42,6 @@ pipeline {
     agent { label 'scf' }
     options {
         ansiColor('xterm')
-        disableConcurrentBuilds()
         timestamps()
         timeout(time: 5, unit: 'HOURS')
     }


### PR DESCRIPTION
We manage concurrent builds at the Jenkins slave level instead, since we only care that there's one build per slave at a time, and not that there's only one build across the whole cluster.