### PR TITLE
cf-usb: Use the correct s3 credentials for prod

### DIFF
--- a/cf-usb/cf-usb.yaml
+++ b/cf-usb/cf-usb.yaml
@@ -50,7 +50,7 @@ resources:
   type: docker-image
   source:
     repository: ((docker-server))((docker-org))/cf-usb-sidecar-dev-mysql-setup
-    tag_as_latest: true
+    tag: ((docker-tag))
     username: ((docker-username))
     password: ((docker-password))
 - name: s3.mysql

--- a/cf-usb/config-production.yaml
+++ b/cf-usb/config-production.yaml
@@ -7,6 +7,9 @@ ci-branch: master
 docker-server: ""
 docker-tag: latest
 
+s3-endpoint: ~
+s3-access-key: *aws-access-key
+s3-secret-key: *aws-secret-key
 s3-bucket: cf-opensusefs2
 s3-prefix: helm/ci/
 s3-disable-ssl: false

--- a/cf-usb/deploy
+++ b/cf-usb/deploy
@@ -17,5 +17,7 @@ fi
 fly set-pipeline \
     --pipeline="cf-usb" \
     --config="cf-usb.yaml" \
-    --load-vars-from="config-${1}.yaml" \
-    --load-vars-from=<(gpg --decrypt --batch --quiet "${CONCOURSE_SECRETS_FILE}")
+    --load-vars-from=<(
+        gpg --decrypt --batch --quiet "${CONCOURSE_SECRETS_FILE}"
+        cat "config-${1}.yaml"
+    )


### PR DESCRIPTION
Change the s3 credentials we use for prod so it goes to the real AWS instead of a testing minio instance that no longer exists.