### PR TITLE
CF-USB: Fix versioning

### DIFF
--- a/cf-usb/cf-usb.yaml
+++ b/cf-usb/cf-usb.yaml
@@ -97,6 +97,8 @@ jobs:
     - get: ci
       passed: [catalog-service-manager]
     - get: semver.cf-usb
+      params:
+        pre: pre
     - get: docker.base
       passed: [catalog-service-manager]
       params:
@@ -147,3 +149,6 @@ jobs:
     - put: s3.mysql
       params:
         file: mysql-helm/cf-usb-*.tgz
+  - put: semver.cf-usb
+    params:
+      pre: pre

--- a/cf-usb/tasks/mysql-build.sh
+++ b/cf-usb/tasks/mysql-build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -o nounset -o errexit -o xtrace
 export GOPATH="${PWD}"
+export START_DIR="${PWD}"
 usbroot=src/github.com/SUSE/cf-usb-sidecar
 svcroot="${usbroot}/csm-extensions/services/dev-mysql"
 make -C "${svcroot}" build helm


### PR DESCRIPTION
Two things:
- Let the build system know that we're CI, so that it doesn't put the user name (`root`) into the generated tag names
- Bump the concourse version resource automatically, so that we get a unique tag for each build