### PR TITLE
rbac fix, takes care of new naming convention of beta3 zips

### DIFF
--- a/helm-deploy-test/config-production.yml
+++ b/helm-deploy-test/config-production.yml
@@ -12,9 +12,9 @@ kube-pool-pool: k8s-hosts
 s3-config-endpoint: ~
 s3-config-access-key: *aws-access-key
 s3-config-secret-key: *aws-secret-key
-s3-config-bucket-opensuse: cf-opensusefs2
+s3-config-bucket-opensuse: cap-release-archives
 s3-config-prefix-opensuse: scf/config/master/
-s3-config-bucket-sles: cap-release-archive
+s3-config-bucket-sles: cap-release-archives
 s3-config-prefix-sles: scf/config/master/
 
 registry-hostname: *docker-internal-registry

--- a/helm-deploy-test/config-production.yml
+++ b/helm-deploy-test/config-production.yml
@@ -13,9 +13,9 @@ s3-config-endpoint: ~
 s3-config-access-key: *aws-access-key
 s3-config-secret-key: *aws-secret-key
 s3-config-bucket-opensuse: cap-release-archives
-s3-config-prefix-opensuse: scf/config/master/
+s3-config-prefix-opensuse: master/
 s3-config-bucket-sles: cap-release-archives
-s3-config-prefix-sles: scf/config/master/
+s3-config-prefix-sles: master/
 
 registry-hostname: *docker-internal-registry
 registry-username: *docker-internal-username

--- a/helm-deploy-test/config-production.yml
+++ b/helm-deploy-test/config-production.yml
@@ -14,8 +14,8 @@ s3-config-access-key: *aws-access-key
 s3-config-secret-key: *aws-secret-key
 s3-config-bucket-opensuse: cf-opensusefs2
 s3-config-prefix-opensuse: scf/config/master/
-s3-config-bucket-sles: cf-opensusefs2
-s3-config-prefix-sles: scf/config/
+s3-config-bucket-sles: cap-release-archive
+s3-config-prefix-sles: scf/config/master/
 
 registry-hostname: *docker-internal-registry
 registry-username: *docker-internal-username

--- a/helm-deploy-test/helm-deploy-test.yml
+++ b/helm-deploy-test/helm-deploy-test.yml
@@ -49,6 +49,8 @@ jobs:
       params: {release: pool.kube-hosts}
   - task: cf-deploy
     file: ci/helm-deploy-test/tasks/cf-deploy.yml
+    params:
+      CAP_CHART: opensuse
     input_mapping:
       s3.scf-config: s3.scf-config-opensuse
   - task: cf-smoke-tests
@@ -69,7 +71,6 @@ jobs:
       TEST_NAME: acceptance-tests
     input_mapping:
       s3.scf-config: s3.scf-config-opensuse
-
   # We intentionally don't put the teardown and pool release steps in an ensure
   # block, so that when tests fail we have a chance of examining why things are
   # failing.
@@ -77,6 +78,7 @@ jobs:
     file: ci/helm-deploy-test/tasks/cf-teardown.yml
   - put: pool.kube-hosts
     params: {release: pool.kube-hosts}
+
 - name: helm-deploy-test-SLES
   plan:
   - aggregate:
@@ -95,6 +97,7 @@ jobs:
       KUBE_REGISTRY_USERNAME: ((registry-username))
       KUBE_REGISTRY_PASSWORD: ((registry-password))
       KUBE_ORGANIZATION: ((organization))
+      CAP_CHART: sles
     input_mapping:
       s3.scf-config: s3.scf-config-sles
   - task: cf-smoke-tests
@@ -115,7 +118,6 @@ jobs:
       TEST_NAME: acceptance-tests
     input_mapping:
       s3.scf-config: s3.scf-config-sles
-
   # We intentionally don't put the teardown and pool release steps in an ensure
   # block, so that when tests fail we have a chance of examining why things are
   # failing.

--- a/helm-deploy-test/helm-deploy-test.yml
+++ b/helm-deploy-test/helm-deploy-test.yml
@@ -107,21 +107,21 @@ jobs:
     file: ci/helm-deploy-test/tasks/run-test.yml
     params:
       TEST_NAME: smoke-tests
-      CAP_CHART: opensuse
+      CAP_CHART: sles
     input_mapping:
       s3.scf-config: s3.scf-config-sles
   - task: acceptance-tests-brain
     file: ci/helm-deploy-test/tasks/run-test.yml
     params:
       TEST_NAME: acceptance-tests-brain
-      CAP_CHART: opensuse
+      CAP_CHART: sles
     input_mapping:
       s3.scf-config: s3.scf-config-sles
   - task: acceptance-tests
     file: ci/helm-deploy-test/tasks/run-test.yml
     params:
       TEST_NAME: acceptance-tests
-      CAP_CHART: opensuse
+      CAP_CHART: sles
     input_mapping:
       s3.scf-config: s3.scf-config-sles
   # We intentionally don't put the teardown and pool release steps in an ensure

--- a/helm-deploy-test/helm-deploy-test.yml
+++ b/helm-deploy-test/helm-deploy-test.yml
@@ -16,7 +16,7 @@ resources:
     access_key_id: ((s3-config-access-key))
     secret_access_key: ((s3-config-secret-key))
     bucket: ((s3-config-bucket-opensuse))
-    regexp: ((s3-config-prefix-opensuse))scf-(.*).linux-amd64\.zip$
+    regexp: ((s3-config-prefix-opensuse))scf-opensuse-(.*).linux-amd64\.zip$
 
 - name: s3.scf-config-sles
   type: s3

--- a/helm-deploy-test/helm-deploy-test.yml
+++ b/helm-deploy-test/helm-deploy-test.yml
@@ -57,18 +57,21 @@ jobs:
     file: ci/helm-deploy-test/tasks/run-test.yml
     params:
       TEST_NAME: smoke-tests
+      CAP_CHART: opensuse
     input_mapping:
       s3.scf-config: s3.scf-config-opensuse
   - task: acceptance-tests-brain
     file: ci/helm-deploy-test/tasks/run-test.yml
     params:
       TEST_NAME: acceptance-tests-brain
+      CAP_CHART: opensuse
     input_mapping:
       s3.scf-config: s3.scf-config-opensuse
   - task: acceptance-tests
     file: ci/helm-deploy-test/tasks/run-test.yml
     params:
       TEST_NAME: acceptance-tests
+      CAP_CHART: opensuse
     input_mapping:
       s3.scf-config: s3.scf-config-opensuse
   # We intentionally don't put the teardown and pool release steps in an ensure
@@ -104,18 +107,21 @@ jobs:
     file: ci/helm-deploy-test/tasks/run-test.yml
     params:
       TEST_NAME: smoke-tests
+      CAP_CHART: opensuse
     input_mapping:
       s3.scf-config: s3.scf-config-sles
   - task: acceptance-tests-brain
     file: ci/helm-deploy-test/tasks/run-test.yml
     params:
       TEST_NAME: acceptance-tests-brain
+      CAP_CHART: opensuse
     input_mapping:
       s3.scf-config: s3.scf-config-sles
   - task: acceptance-tests
     file: ci/helm-deploy-test/tasks/run-test.yml
     params:
       TEST_NAME: acceptance-tests
+      CAP_CHART: opensuse
     input_mapping:
       s3.scf-config: s3.scf-config-sles
   # We intentionally don't put the teardown and pool release steps in an ensure

--- a/helm-deploy-test/tasks/cf-deploy.sh
+++ b/helm-deploy-test/tasks/cf-deploy.sh
@@ -52,14 +52,14 @@ fi
 
 # Deploy UAA
 kubectl create namespace "${UAA_NAMESPACE}"
-helm install s3.scf-config/helm/uaa/ \
+helm install s3.scf-config/helm/uaa-${CAP_CHART}/ \
     --namespace "${UAA_NAMESPACE}" \
     --values certs/uaa-cert-values.yaml \
     "${HELM_PARAMS[@]}"
 
 # Deploy CF
 kubectl create namespace "${CF_NAMESPACE}"
-helm install s3.scf-config/helm/cf/ \
+helm install s3.scf-config/helm/cf-${CAP_CHART}/ \
     --namespace "${CF_NAMESPACE}" \
     --values certs/scf-cert-values.yaml \
     --set "env.CLUSTER_ADMIN_PASSWORD=${CLUSTER_ADMIN_PASSWORD:-changeme}" \

--- a/helm-deploy-test/tasks/cf-deploy.sh
+++ b/helm-deploy-test/tasks/cf-deploy.sh
@@ -35,7 +35,8 @@ popd
 
 HELM_PARAMS=(--set "env.DOMAIN=${DOMAIN}"
              --set "env.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}"
-             --set "kube.external_ip=${external_ip}")
+             --set "kube.external_ip=${external_ip}"
+             --set "kube.auth=rbac")
 if [ -n "${KUBE_REGISTRY_HOSTNAME:-}" ]; then
     HELM_PARAMS+=(--set "kube.registry.hostname=${KUBE_REGISTRY_HOSTNAME}")
 fi

--- a/helm-deploy-test/tasks/run-test.sh
+++ b/helm-deploy-test/tasks/run-test.sh
@@ -27,11 +27,11 @@ kube_overrides() {
 EOF
 }
 
-image=$(awk '$1 == "image:" { gsub(/"/, "", $2); print $2 }' "s3.scf-config/kube/cf/bosh-task/${TEST_NAME}.yaml")
+image=$(awk '$1 == "image:" { gsub(/"/, "", $2); print $2 }' "s3.scf-config/kube/cf-${CAP_CHART}/bosh-task/${TEST_NAME}.yaml")
 kubectl run \
     --namespace="${CF_NAMESPACE}" \
     --attach \
     --restart=Never \
     --image="${image}" \
-    --overrides="$(kube_overrides "s3.scf-config/kube/cf/bosh-task/${TEST_NAME}.yaml")" \
+    --overrides="$(kube_overrides "s3.scf-config/kube/cf-${CAP_CHART}/bosh-task/${TEST_NAME}.yaml")" \
     "${TEST_NAME}"


### PR DESCRIPTION
https://trello.com/c/2CNhlg6A/461-ci-fix-qa-pipeline-for-new-cap-bits

https://ci.howdoi.website/teams/main/pipelines/prabal-rbac-helm-deploy/jobs/helm-deploy-test-openSUSE/builds/1
Smokes failed later, but also the watcher which was looking at its status failed. You can do k logs :smoke to check the status.
Test failure will be handled in separate ticket