### PR TITLE
Future-proof kube non-master node IP determination

### DIFF
--- a/helm-deploy-test/tasks/cf-deploy.sh
+++ b/helm-deploy-test/tasks/cf-deploy.sh
@@ -6,8 +6,8 @@ mkdir -p /root/.kube/
 cp  pool.kube-hosts/metadata /root/.kube/config
 
 set -o allexport
-# The IP address assigned to the kube node.
-external_ip=$(kubectl get nodes -o jsonpath='{.items[].status.addresses[?(@.type=="InternalIP")].address}' | head -n1)
+# The IP address assigned to the first kubelet node.
+external_ip=$(kubectl get nodes -o json | jq -r '.items[] | select(.spec.unschedulable == true | not) | .metadata.annotations["alpha.kubernetes.io/provided-node-ip"]' | head -n1)
 # Domain for SCF. DNS for *.DOMAIN must point to the kube node's
 # external ip. This must match the value passed to the
 # cert-generator.sh script.

--- a/helm-deploy-test/tasks/run-test.sh
+++ b/helm-deploy-test/tasks/run-test.sh
@@ -6,7 +6,7 @@ mkdir -p /root/.kube/
 cp  pool.kube-hosts/metadata /root/.kube/config
 
 set -o allexport
-DOMAIN=$(kubectl get nodes -o jsonpath='{.items[].status.addresses[?(@.type=="InternalIP")].address}' | head -n1).nip.io
+DOMAIN=$(kubectl get pods -o json --namespace scf api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
 CF_NAMESPACE=scf
 set +o allexport
 


### PR DESCRIPTION
Currently the node IP to use for DOMAIN is obtained from a jsonpath
query which lists all node IPs and takes the first one. Incidentally
this seems to be a non-master node in our deployments so far, but
nothing I've seen in the CaaSP and kubernetes documentation indicates
this order is specified in any way. Since our master nodes will always
have the 'unschedulable' property set to true, we should use a jq
filter to get the first IP from the set of nodes which *are*
shedulable.