### PR TITLE
Improve domain determination

### DIFF
--- a/helm-deploy-test/tasks/cf-deploy.sh
+++ b/helm-deploy-test/tasks/cf-deploy.sh
@@ -6,8 +6,8 @@ mkdir -p /root/.kube/
 cp  pool.kube-hosts/metadata /root/.kube/config
 
 set -o allexport
-# The IP address assigned to the kube node.
-external_ip=$(kubectl get nodes -o jsonpath='{.items[].status.addresses[?(@.type=="InternalIP")].address}' | head -n1)
+# The IP address assigned to the first kubelet node.
+external_ip=$(kubectl get nodes -o json | jq -r '.items[] | select(.spec.unschedulable == true | not) | .metadata.annotations["alpha.kubernetes.io/provided-node-ip"]' | head -n1)
 # Domain for SCF. DNS for *.DOMAIN must point to the kube node's
 # external ip. This must match the value passed to the
 # cert-generator.sh script.

--- a/helm-deploy-test/tasks/run-test.sh
+++ b/helm-deploy-test/tasks/run-test.sh
@@ -6,7 +6,7 @@ mkdir -p /root/.kube/
 cp  pool.kube-hosts/metadata /root/.kube/config
 
 set -o allexport
-DOMAIN=$(kubectl get nodes -o jsonpath='{.items[].status.addresses[?(@.type=="InternalIP")].address}' | head -n1).nip.io
+DOMAIN=$(kubectl get pods -o json --namespace scf api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
 CF_NAMESPACE=scf
 set +o allexport
 


### PR DESCRIPTION
Improve the way the domain for SCF is determined when deploying SCF. This PR changes the way the node IP to use is selected (the previous jsonpath would occasionally select the master IP) by filtering out nodes which have the unschedulable property set.

When running tests, the test script also now retrieves the SCF DOMAIN value from the api pod env, which is more robust.