### PR TITLE
Explicitly name helm releases and improve teardown

### DIFF
--- a/helm-deploy-test/tasks/cf-deploy.sh
+++ b/helm-deploy-test/tasks/cf-deploy.sh
@@ -81,6 +81,7 @@ if [[ ${PROVISIONER} == kubernetes.io/rbd ]]; then
 fi
 helm install s3.scf-config/helm/uaa${CAP_CHART}/ \
     --namespace "${UAA_NAMESPACE}" \
+    --name uaa \
     "${HELM_PARAMS[@]}"
 
 # Wait for UAA namespace
@@ -101,6 +102,7 @@ if [[ ${PROVISIONER} == kubernetes.io/rbd ]]; then
 fi
 helm install s3.scf-config/helm/cf${CAP_CHART}/ \
     --namespace "${CF_NAMESPACE}" \
+    --name scf \
     --set "env.CLUSTER_ADMIN_PASSWORD=${CLUSTER_ADMIN_PASSWORD:-changeme}" \
     --set "env.UAA_HOST=${UAA_HOST}" \
     --set "env.UAA_PORT=${UAA_PORT}" \

--- a/helm-deploy-test/tasks/cf-teardown.sh
+++ b/helm-deploy-test/tasks/cf-teardown.sh
@@ -11,11 +11,9 @@ UAA_NAMESPACE=uaa
 set +o allexport
 
 for namespace in "$CF_NAMESPACE" "$UAA_NAMESPACE" ; do
-    for name in $(helm list --deployed --short --namespace "${namespace}") ; do
-        helm delete "${name}" || true
-    done
-    while kubectl get namespace "${namespace}" ; do
-        kubectl delete namespace "${namespace}" || true
+    kubectl delete namespace "${namespace}" || true
+    while [[ -n $(helm list --short --all ${namespace}) ]]; do
         sleep 10
+        helm delete --purge ${namespace};
     done
 done

--- a/helm-deploy-test/tasks/cf-teardown.sh
+++ b/helm-deploy-test/tasks/cf-teardown.sh
@@ -11,9 +11,9 @@ UAA_NAMESPACE=uaa
 set +o allexport
 
 for namespace in "$CF_NAMESPACE" "$UAA_NAMESPACE" ; do
-    kubectl delete namespace "${namespace}" || true
+    kubectl delete namespace "${namespace}"
     while [[ -n $(helm list --short --all ${namespace}) ]]; do
         sleep 10
-        helm delete --purge ${namespace};
+        helm delete --purge ${namespace} ||:
     done
 done


### PR DESCRIPTION
Explicity naming these will facilitate upgrade testing, as we don't
have to determine the name of the correct release to upgrade in that
task.