### PR TITLE
Fix bug with is_namespace_ready() in cf-deploy

### DIFF
--- a/helm-deploy-test/tasks/cf-deploy.sh
+++ b/helm-deploy-test/tasks/cf-deploy.sh
@@ -47,10 +47,10 @@ fi
 # Wait until CF namespaces are ready
 is_namespace_ready() {
     local namespace="$1"
-    $(kubectl get pods --namespace=${namespace} --output=custom-columns=':.status.containerStatuses[].ready' \
+    [[ true == $(kubectl get pods --namespace=${namespace} --output=custom-columns=':.status.containerStatuses[].ready' \
         | sed '/^$/d' \
         | sort \
-        | uniq)
+        | uniq) ]]
 }
 
 wait_for_namespace() {


### PR DESCRIPTION
If the containerStatuses are grabbed before there are any containers to
get the status of, a no-op is evaluated on the last line, which is
truthy