### PR TITLE
Increase timeout on helm install to 600

### DIFF
--- a/helm-deploy-test/tasks/cf-deploy.sh
+++ b/helm-deploy-test/tasks/cf-deploy.sh
@@ -82,6 +82,7 @@ fi
 helm install s3.scf-config/helm/uaa${CAP_CHART}/ \
     --namespace "${UAA_NAMESPACE}" \
     --name uaa \
+    --timeout 600 \
     "${HELM_PARAMS[@]}"
 
 # Wait for UAA namespace
@@ -109,6 +110,7 @@ fi
 helm install s3.scf-config/helm/cf${CAP_CHART}/ \
     --namespace "${CF_NAMESPACE}" \
     --name scf \
+    --timeout 600 \
     --set "env.CLUSTER_ADMIN_PASSWORD=${CLUSTER_ADMIN_PASSWORD:-changeme}" \
     --set "env.UAA_HOST=${UAA_HOST}" \
     --set "env.UAA_PORT=${UAA_PORT}" \


### PR DESCRIPTION
The default timeout here is 300; sometimes the release installation
takes longer and we end up hitting the following error:

```
E0105 02:32:08.574555     480 portforward.go:178] lost connection to pod
Error: transport is closing
```