### PR TITLE
CI updates for the  sidecar'd mysql broker

### DIFF
--- a/cf-usb/cf-usb.yaml
+++ b/cf-usb/cf-usb.yaml
@@ -1,4 +1,12 @@
 ---
+resource_types:
+- name: docker-image-resource
+  type: docker-image
+  privileged: true
+  source:
+    repository: concourse/docker-image-resource
+    tag: latest
+
 resources:
 - name: src
   type: git
@@ -26,28 +34,28 @@ resources:
     endpoint: ((s3-endpoint))
     disable_ssl: ((s3-disable-ssl))
 - name: docker.base
-  type: docker-image
+  type: docker-image-resource
   source:
     repository: ((docker-server))((docker-org))/cf-usb-sidecar
     tag: ((docker-tag))
     username: ((docker-username))
     password: ((docker-password))
 - name: docker.buildbase
-  type: docker-image
+  type: docker-image-resource
   source:
     repository: ((docker-server))((docker-org))/cf-usb-sidecar-buildbase
     tag: ((docker-tag))
     username: ((docker-username))
     password: ((docker-password))
 - name: docker.mysql
-  type: docker-image
+  type: docker-image-resource
   source:
     repository: ((docker-server))((docker-org))/cf-usb-sidecar-mysql
     tag: ((docker-tag))
     username: ((docker-username))
     password: ((docker-password))
 - name: docker.mysql-setup
-  type: docker-image
+  type: docker-image-resource
   source:
     repository: ((docker-server))((docker-org))/cf-usb-sidecar-mysql-setup
     tag: ((docker-tag))
@@ -142,7 +150,7 @@ jobs:
     - put: docker.mysql
       params:
         build: mysql-binary
-        load_base: docker.base-fixed
+        load_bases: [ docker.base-fixed, docker.buildbase-fixed ]
         tag_as_latest: true
         tag: mysql-binary/tag
     - put: docker.mysql-setup

--- a/cf-usb/cf-usb.yaml
+++ b/cf-usb/cf-usb.yaml
@@ -71,23 +71,29 @@ jobs:
       trigger: true
     - get: ci
       trigger: true
-  - aggregate:
-    - do:
-      - task: generate
-        file: ci/cf-usb/tasks/csm-generate.yml
-      - task: build
-        file: ci/cf-usb/tasks/csm-build.yml
-        output_mapping:
-          out: csm-binary
-      - put: docker.base
-        params:
-          tag_as_latest: true
-          build: csm-binary
-    - put: docker.buildbase
-      params:
-        tag_as_latest: true
-        build: src
-        dockerfile: src/scripts/docker/Dockerfile-build
+  - task: generate
+    file: ci/cf-usb/tasks/csm-generate.yml
+  - task: build
+    file: ci/cf-usb/tasks/csm-build.yml
+    output_mapping:
+      out: csm-binary
+  - put: docker.buildbase
+    get_params: {save: true}
+    params:
+      tag_as_latest: true
+      build: src
+      dockerfile: src/scripts/docker/Dockerfile-build
+  - task: fix-buildbase
+    file: ci/cf-usb/tasks/fix-base.yml
+    input_mapping:
+      in: docker.buildbase
+    output_mapping:
+      out: docker.buildbase-fixed
+  - put: docker.base
+    params:
+      load_base: docker.buildbase-fixed
+      tag_as_latest: true
+      build: csm-binary
 - name: sidecar-mysql
   plan:
   - aggregate:
@@ -148,7 +154,7 @@ jobs:
         tag: mysql-binary/tag
     - put: s3.mysql
       params:
-        file: mysql-helm/cf-usb-*.tgz
+        file: mysql-helm/cf-usb-sidecar-mysql*.tgz
   - put: semver.cf-usb-sidecar-mysql
     params:
       pre: pre

--- a/cf-usb/cf-usb.yaml
+++ b/cf-usb/cf-usb.yaml
@@ -20,7 +20,7 @@ resources:
     initial_version: 0.0.0
     driver: s3
     bucket: ((s3-bucket))
-    key: ((s3-prefix))cf-usb.version
+    key: ((s3-prefix))cf-usb-sidecar-mysql.version
     access_key_id: ((s3-access-key))
     secret_access_key: ((s3-secret-key))
     endpoint: ((s3-endpoint))
@@ -42,14 +42,14 @@ resources:
 - name: docker.mysql
   type: docker-image
   source:
-    repository: ((docker-server))((docker-org))/cf-usb-sidecar-dev-mysql
+    repository: ((docker-server))((docker-org))/cf-usb-sidecar-mysql
     tag: ((docker-tag))
     username: ((docker-username))
     password: ((docker-password))
 - name: docker.mysql-setup
   type: docker-image
   source:
-    repository: ((docker-server))((docker-org))/cf-usb-sidecar-dev-mysql-setup
+    repository: ((docker-server))((docker-org))/cf-usb-sidecar-mysql-setup
     tag: ((docker-tag))
     username: ((docker-username))
     password: ((docker-password))
@@ -88,7 +88,7 @@ jobs:
         tag_as_latest: true
         build: src
         dockerfile: src/scripts/docker/Dockerfile-build
-- name: dev-mysql
+- name: sidecar-mysql
   plan:
   - aggregate:
     - get: src

--- a/cf-usb/cf-usb.yaml
+++ b/cf-usb/cf-usb.yaml
@@ -135,6 +135,8 @@ jobs:
         file: ci/cf-usb/tasks/csm-generate.yml
       - task: build
         file: ci/cf-usb/tasks/mysql-build.yml
+        params:
+          DESTINATION: ((docker-server))
         input_mapping:
           version: semver.cf-usb-sidecar-mysql
         output_mapping:

--- a/cf-usb/cf-usb.yaml
+++ b/cf-usb/cf-usb.yaml
@@ -1,11 +1,17 @@
 ---
 resource_types:
-- name: docker-image-resource
+- name: docker-image
   type: docker-image
   privileged: true
   source:
     repository: concourse/docker-image-resource
     tag: latest
+
+# This resource-type is needed because we require the `load_bases`
+# keyword to handle the broker jobs. This feature exists for only 8
+# days now, relative to Jan 26, 2018. The import can be removed when
+# we are updated to a concourse which has this version of the resource
+# type built into it (v321 has not).
 
 resources:
 - name: src
@@ -34,28 +40,28 @@ resources:
     endpoint: ((s3-endpoint))
     disable_ssl: ((s3-disable-ssl))
 - name: docker.base
-  type: docker-image-resource
+  type: docker-image
   source:
     repository: ((docker-server))((docker-org))/cf-usb-sidecar
     tag: ((docker-tag))
     username: ((docker-username))
     password: ((docker-password))
 - name: docker.buildbase
-  type: docker-image-resource
+  type: docker-image
   source:
     repository: ((docker-server))((docker-org))/cf-usb-sidecar-buildbase
     tag: ((docker-tag))
     username: ((docker-username))
     password: ((docker-password))
 - name: docker.mysql
-  type: docker-image-resource
+  type: docker-image
   source:
     repository: ((docker-server))((docker-org))/cf-usb-sidecar-mysql
     tag: ((docker-tag))
     username: ((docker-username))
     password: ((docker-password))
 - name: docker.mysql-setup
-  type: docker-image-resource
+  type: docker-image
   source:
     repository: ((docker-server))((docker-org))/cf-usb-sidecar-mysql-setup
     tag: ((docker-tag))
@@ -150,7 +156,9 @@ jobs:
     - put: docker.mysql
       params:
         build: mysql-binary
-        load_bases: [ docker.base-fixed, docker.buildbase-fixed ]
+        load_bases:
+        - docker.base-fixed
+        - docker.buildbase-fixed
         tag_as_latest: true
         tag: mysql-binary/tag
     - put: docker.mysql-setup

--- a/cf-usb/cf-usb.yaml
+++ b/cf-usb/cf-usb.yaml
@@ -14,7 +14,7 @@ resources:
     branch: ((ci-branch))
     paths:
     - cf-usb/tasks
-- name: semver.cf-usb
+- name: semver.cf-usb-sidecar-mysql
   type: semver
   source:
     initial_version: 0.0.0
@@ -96,7 +96,7 @@ jobs:
       trigger: true
     - get: ci
       passed: [catalog-service-manager]
-    - get: semver.cf-usb
+    - get: semver.cf-usb-sidecar-mysql
       params:
         pre: pre
     - get: docker.base
@@ -116,7 +116,7 @@ jobs:
       - task: build
         file: ci/cf-usb/tasks/mysql-build.yml
         input_mapping:
-          version: semver.cf-usb
+          version: semver.cf-usb-sidecar-mysql
         output_mapping:
           docker-out: mysql-binary
           helm-out: mysql-helm
@@ -149,6 +149,6 @@ jobs:
     - put: s3.mysql
       params:
         file: mysql-helm/cf-usb-*.tgz
-  - put: semver.cf-usb
+  - put: semver.cf-usb-sidecar-mysql
     params:
       pre: pre

--- a/cf-usb/cf-usb.yaml
+++ b/cf-usb/cf-usb.yaml
@@ -67,6 +67,13 @@ resources:
     tag: ((docker-tag))
     username: ((docker-username))
     password: ((docker-password))
+- name: docker.mysql-db
+  type: docker-image
+  source:
+    repository: ((docker-server))((docker-org))/cf-usb-sidecar-mysql-db
+    tag: ((docker-tag))
+    username: ((docker-username))
+    password: ((docker-password))
 - name: s3.mysql
   type: s3
   source:
@@ -168,6 +175,12 @@ jobs:
         build: mysql-binary
         dockerfile: mysql-binary/Dockerfile-setup
         load_base: docker.buildbase-fixed
+        tag_as_latest: true
+        tag: mysql-binary/tag
+    - put: docker.mysql-db
+      params:
+        build: mysql-binary
+        dockerfile: mysql-binary/Dockerfile-db
         tag_as_latest: true
         tag: mysql-binary/tag
     - put: s3.mysql

--- a/cf-usb/config-production.yaml
+++ b/cf-usb/config-production.yaml
@@ -10,6 +10,6 @@ docker-tag: latest
 s3-endpoint: ~
 s3-access-key: *aws-access-key
 s3-secret-key: *aws-secret-key
-s3-bucket: cf-opensusefs2
-s3-prefix: helm/ci/
+s3-bucket: cap-release-archives
+s3-prefix: brokers/
 s3-disable-ssl: false

--- a/cf-usb/config-production.yaml
+++ b/cf-usb/config-production.yaml
@@ -4,8 +4,10 @@ src-branch: develop
 ci-repo: https://github.com/SUSE/cf-ci.git
 ci-branch: master
 
-docker-server: ""
 docker-tag: latest
+docker-server: "staging.registry.howdoi.website/"
+docker-username: *docker-internal-username
+docker-password: *docker-internal-password
 
 s3-endpoint: ~
 s3-access-key: *aws-access-key

--- a/cf-usb/tasks/csm-build.sh
+++ b/cf-usb/tasks/csm-build.sh
@@ -14,7 +14,7 @@ cd "${SIDECAR_ROOT}"
 if ! test -d vendor ; then
     # Symlinks don't work here because go(.exe) expands the symlink then falls over
     cp -r Godeps/_workspace/src vendor
-    cp -r go-swagger/src/* vendor/
 fi
+cp -r go-swagger/src/* vendor/
 mkdir -p "${GOBIN}"
 go install ./cmd/catalog-service-manager

--- a/cf-usb/tasks/csm-build.sh
+++ b/cf-usb/tasks/csm-build.sh
@@ -11,10 +11,6 @@ cp -r "${SIDECAR_ROOT}/docs/package-files" out/docs/
 cp "${SIDECAR_ROOT}/scripts/docker/release/Dockerfile-release" out/Dockerfile
 
 cd "${SIDECAR_ROOT}"
-if ! test -d vendor ; then
-    # Symlinks don't work here because go(.exe) expands the symlink then falls over
-    cp -r Godeps/_workspace/src vendor
-fi
 cp -r go-swagger/src/* vendor/
 mkdir -p "${GOBIN}"
 go install ./cmd/catalog-service-manager

--- a/cf-usb/tasks/csm-generate.sh
+++ b/cf-usb/tasks/csm-generate.sh
@@ -8,8 +8,8 @@ cd "${SIDECAR_ROOT}"
 if ! test -d vendor ; then
     # Symlinks don't work here because go(.exe) expands the symlink then falls over
     cp -r Godeps/_workspace/src vendor
-    cp -r go-swagger/src/* vendor/
 fi
+cp -r go-swagger/src/* vendor/
 
 "${SIDECAR_ROOT}/scripts/generate-server.sh"
 "${SIDECAR_ROOT}/scripts/generate-csm-client.sh"

--- a/cf-usb/tasks/csm-generate.sh
+++ b/cf-usb/tasks/csm-generate.sh
@@ -5,10 +5,6 @@ export SIDECAR_ROOT="${ROOT}/src/github.com/SUSE/cf-usb-sidecar"
 export GOBIN="${ROOT}/out/"
 export GOPATH="${ROOT}"
 cd "${SIDECAR_ROOT}"
-if ! test -d vendor ; then
-    # Symlinks don't work here because go(.exe) expands the symlink then falls over
-    cp -r Godeps/_workspace/src vendor
-fi
 cp -r go-swagger/src/* vendor/
 
 "${SIDECAR_ROOT}/scripts/generate-server.sh"

--- a/cf-usb/tasks/mysql-build.sh
+++ b/cf-usb/tasks/mysql-build.sh
@@ -2,8 +2,9 @@
 set -o nounset -o errexit -o xtrace
 export GOPATH="${PWD}"
 export START_DIR="${PWD}"
+service=mysql
 usbroot=src/github.com/SUSE/cf-usb-sidecar
-svcroot="${usbroot}/csm-extensions/services/dev-mysql"
+svcroot="${usbroot}/csm-extensions/services/dev-${service}"
 make -C "${svcroot}" build helm
 
 # Note that this moves the whole SIDECAR_HOME directory as a _subdirectory_ of out/
@@ -16,4 +17,4 @@ if test -z "${APP_VERSION_TAG:-}" ; then
     APP_VERSION_TAG="$(cd "${usbroot}" && scripts/build_version.sh "APP_VERSION_TAG")"
 fi
 echo "${APP_VERSION_TAG}" > docker-out/tag
-tar -czf helm-out/cf-usb-${APP_VERSION_TAG}.tgz -C "${svcroot}/output/helm/" .
+tar -czf helm-out/cf-usb-sidecar-${service}-${APP_VERSION_TAG}.tgz -C "${svcroot}/output/helm/" .

--- a/cf-usb/tasks/mysql-build.yml
+++ b/cf-usb/tasks/mysql-build.yml
@@ -5,8 +5,6 @@ image_resource:
   source:
     repository: golang
     tag: latest
-args:
-- mysql
 inputs:
 - name: src
   path: src/github.com/SUSE/cf-usb-sidecar
@@ -17,4 +15,6 @@ outputs:
 - name: helm-out
 - name: docker-out
 run:
+  args:
+  - mysql
   path: ci/cf-usb/tasks/service-build.sh

--- a/cf-usb/tasks/mysql-build.yml
+++ b/cf-usb/tasks/mysql-build.yml
@@ -5,6 +5,8 @@ image_resource:
   source:
     repository: golang
     tag: latest
+args:
+- mysql
 inputs:
 - name: src
   path: src/github.com/SUSE/cf-usb-sidecar
@@ -15,4 +17,4 @@ outputs:
 - name: helm-out
 - name: docker-out
 run:
-  path: ci/cf-usb/tasks/mysql-build.sh
+  path: ci/cf-usb/tasks/service-build.sh

--- a/cf-usb/tasks/service-build.sh
+++ b/cf-usb/tasks/service-build.sh
@@ -7,6 +7,16 @@ usbroot=src/github.com/SUSE/cf-usb-sidecar
 svcroot="${usbroot}/csm-extensions/services/dev-${service}"
 make -C "${svcroot}" build helm
 
+# Default destination, and strip a trailing slash.
+DESTINATION=${DESTINATION:-docker.io}
+DESTINATION=${DESTINATION%/}
+
+# Place chosen destination into the chart.
+sed -i "s|docker.io|$DESTINATION|" "${svcroot}/output/helm/values.yaml"
+
+# Trigger generation of proper APP_VERSION_TAG
+CONCOURSEBUILD=1
+
 # Note that this moves the whole SIDECAR_HOME directory as a _subdirectory_ of out/
 mv "${svcroot}/SIDECAR_HOME" docker-out/
 cp "${svcroot}/Dockerfile" docker-out/

--- a/cf-usb/tasks/service-build.sh
+++ b/cf-usb/tasks/service-build.sh
@@ -2,7 +2,7 @@
 set -o nounset -o errexit -o xtrace
 export GOPATH="${PWD}"
 export START_DIR="${PWD}"
-service=mysql
+service=$1
 usbroot=src/github.com/SUSE/cf-usb-sidecar
 svcroot="${usbroot}/csm-extensions/services/dev-${service}"
 make -C "${svcroot}" build helm

--- a/cf-usb/tasks/service-build.sh
+++ b/cf-usb/tasks/service-build.sh
@@ -15,7 +15,7 @@ DESTINATION=${DESTINATION%/}
 sed -i "s|docker.io|$DESTINATION|" "${svcroot}/output/helm/values.yaml"
 
 # Trigger generation of proper APP_VERSION_TAG
-CONCOURSEBUILD=1
+export CONCOURSE_BUILD=1
 
 # Note that this moves the whole SIDECAR_HOME directory as a _subdirectory_ of out/
 mv "${svcroot}/SIDECAR_HOME" docker-out/

--- a/cf-usb/tasks/service-build.sh
+++ b/cf-usb/tasks/service-build.sh
@@ -5,6 +5,10 @@ export START_DIR="${PWD}"
 service=$1
 usbroot=src/github.com/SUSE/cf-usb-sidecar
 svcroot="${usbroot}/csm-extensions/services/dev-${service}"
+
+# Trigger generation of proper APP_VERSION_TAG
+export CONCOURSE_BUILD=1
+
 make -C "${svcroot}" build helm
 
 # Default destination, and strip a trailing slash.
@@ -13,9 +17,6 @@ DESTINATION=${DESTINATION%/}
 
 # Place chosen destination into the chart.
 sed -i "s|docker.io|$DESTINATION|" "${svcroot}/output/helm/values.yaml"
-
-# Trigger generation of proper APP_VERSION_TAG
-export CONCOURSE_BUILD=1
 
 # Note that this moves the whole SIDECAR_HOME directory as a _subdirectory_ of out/
 mv "${svcroot}/SIDECAR_HOME" docker-out/

--- a/cf-usb/tasks/service-build.sh
+++ b/cf-usb/tasks/service-build.sh
@@ -19,10 +19,11 @@ DESTINATION=${DESTINATION%/}
 sed -i "s|docker.io|$DESTINATION|" "${svcroot}/output/helm/values.yaml"
 
 # Note that this moves the whole SIDECAR_HOME directory as a _subdirectory_ of out/
-mv "${svcroot}/SIDECAR_HOME" docker-out/
-cp "${svcroot}/Dockerfile" docker-out/
+mv "${svcroot}/SIDECAR_HOME"     docker-out/
+cp "${svcroot}/Dockerfile"       docker-out/
 cp "${svcroot}/Dockerfile-setup" docker-out/
-cp -r "${svcroot}/chart" docker-out/
+cp "${svcroot}/Dockerfile-db"    docker-out/
+cp -r "${svcroot}/chart"         docker-out/
 
 if test -z "${APP_VERSION_TAG:-}" ; then
     APP_VERSION_TAG="$(cd "${usbroot}" && scripts/build_version.sh "APP_VERSION_TAG")"


### PR DESCRIPTION
https://trello.com/c/MlwUS1BE/537-3-ci-for-mysql-broker

- Redirect generated helm charts to the proper and official location in SUSE s3
- Redirect generated docker images to proper and official SUSE staging registry

General fixups to handle the upheaval brought by the switch from `Godeps` to `vendor`.
Some proactive name changes to make future addition of more brokers easier.
