### PR TITLE
CF-USB sidecar bundle publishing

### DIFF
--- a/cf-usb/cf-usb.yaml
+++ b/cf-usb/cf-usb.yaml
@@ -257,6 +257,37 @@ jobs:
   - put: semver.cf-usb-sidecar-mysql
     params:
       pre: pre
+- name: sidecar-publish-mysql
+  plan:
+  - aggregate:
+    # NOTE: none of this have trigger: because this *must* be a manual step
+    - get: src
+      passed: [sidecar-mysql]
+    - get: ci
+      passed: [sidecar-mysql]
+    - get: s3.mysql
+      passed: [sidecar-mysql]
+    - get: docker.buildbase
+      passed: [sidecar-mysql]
+  - aggregate:
+    - task: image-link
+      image: docker.buildbase
+      file: ci/cf-usb/tasks/service-image-link.yml
+      params:
+        RELEASE_TOOL_URL: ((charts-release-tool-url))
+      input_mapping:
+        bundle: s3.mysql
+    - task: publish
+      image: docker.buildbase
+      file: ci/cf-usb/tasks/service-publish.yml
+      params:
+        SERVICE: mysql
+        GITHUB_USER: ((charts-github-username))
+        GITHUB_PASSWORD: ((charts-github-password))
+        GITHUB_KEY: ((charts-github-private-key))
+        GITHUB_ORGANIZATION: ((charts-github-org))
+      input_mapping:
+        bundle: s3.mysql
 - name: sidecar-postgres
   plan:
   - aggregate:
@@ -340,3 +371,34 @@ jobs:
   - put: semver.cf-usb-sidecar-postgres
     params:
       pre: pre
+- name: sidecar-publish-postgres
+  plan:
+  - aggregate:
+    # NOTE: none of this have trigger: because this *must* be a manual step
+    - get: src
+      passed: [sidecar-postgres]
+    - get: ci
+      passed: [sidecar-postgres]
+    - get: s3.postgres
+      passed: [sidecar-postgres]
+    - get: docker.buildbase
+      passed: [sidecar-postgres]
+  - aggregate:
+    - task: image-link
+      image: docker.buildbase
+      file: ci/cf-usb/tasks/service-image-link.yml
+      params:
+        RELEASE_TOOL_URL: ((charts-release-tool-url))
+      input_mapping:
+        bundle: s3.postgres
+    - task: publish
+      image: docker.buildbase
+      file: ci/cf-usb/tasks/service-publish.yml
+      params:
+        SERVICE: postgres
+        GITHUB_USER: ((charts-github-username))
+        GITHUB_PASSWORD: ((charts-github-password))
+        GITHUB_KEY: ((charts-github-private-key))
+        GITHUB_ORGANIZATION: ((charts-github-org))
+      input_mapping:
+        bundle: s3.postgres

--- a/cf-usb/config-sle-production-master.yaml
+++ b/cf-usb/config-sle-production-master.yaml
@@ -1,0 +1,31 @@
+src-repo: https://github.com/SUSE/cf-usb-sidecar.git
+src-branch: master
+
+ci-repo: https://github.com/SUSE/cf-ci.git
+ci-branch: master
+
+docker-tag: latest
+docker-server: *docker-internal-registry
+docker-username: *docker-internal-username
+docker-password: *docker-internal-password
+
+docker-cert-domain: *docker-public-registry
+docker-cert-ca: *ca-cert-suse
+
+buildbase-base-image:              *docker-image-sles
+buildbase-repo-cloud-tools:        *zypper-repo-sle-server
+buildbase-repo-devel-languages-go: *zypper-repo-sle-sdk
+buildbase-repo-extra:              *zypper-repo-ibs-ga
+
+charts-release-tool-url: *cap-release-tool-url
+charts-github-username: *github-username
+charts-github-password: *github-password
+charts-github-private-key: *github-private-key
+charts-github-org: SUSE
+
+s3-endpoint: ~
+s3-access-key: *aws-access-key
+s3-secret-key: *aws-secret-key
+s3-bucket: cap-release-archives
+s3-prefix: brokers/
+s3-disable-ssl: false

--- a/cf-usb/tasks/service-build.sh
+++ b/cf-usb/tasks/service-build.sh
@@ -5,6 +5,10 @@ export START_DIR="${PWD}"
 usbroot=src/github.com/SUSE/cf-usb-sidecar
 svcroot="${usbroot}/csm-extensions/services/dev-${SERVICE}"
 
+if test -z "${APP_VERSION_TAG:-}" ; then
+    export APP_VERSION_TAG="$(cd "${usbroot}" && scripts/build_version.sh "APP_VERSION_TAG")"
+fi
+
 make -C "${svcroot}" build helm
 
 # Default destination, and strip a trailing slash.
@@ -21,8 +25,5 @@ cp "${svcroot}/Dockerfile-setup" docker-out/
 cp "${svcroot}/Dockerfile-db"    docker-out/
 cp -r "${svcroot}/chart"         docker-out/
 
-if test -z "${APP_VERSION_TAG:-}" ; then
-    APP_VERSION_TAG="$(cd "${usbroot}" && scripts/build_version.sh "APP_VERSION_TAG")"
-fi
 echo "${APP_VERSION_TAG}" > docker-out/tag
 tar -czf helm-out/cf-usb-sidecar-${SERVICE}-${APP_VERSION_TAG}.tgz -C "${svcroot}/output/helm/" .

--- a/cf-usb/tasks/service-build.sh
+++ b/cf-usb/tasks/service-build.sh
@@ -5,9 +5,6 @@ export START_DIR="${PWD}"
 usbroot=src/github.com/SUSE/cf-usb-sidecar
 svcroot="${usbroot}/csm-extensions/services/dev-${SERVICE}"
 
-# Trigger generation of proper APP_VERSION_TAG
-export CONCOURSE_BUILD=1
-
 make -C "${svcroot}" build helm
 
 # Default destination, and strip a trailing slash.

--- a/cf-usb/tasks/service-image-link.sh
+++ b/cf-usb/tasks/service-image-link.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+# This script just displays the link necessary to copy the docker images to the
+# production registry
+
+# The helm chart bundle URL, URL escaped.
+export BUNDLE_URL="$(perl -lpe 's/(\W)/sprintf("%%%02X", ord($1))/ge' < bundle/url)"
+echo "${RELEASE_TOOL_URL}?release_archive_url=${BUNDLE_URL}"

--- a/cf-usb/tasks/service-image-link.yml
+++ b/cf-usb/tasks/service-image-link.yml
@@ -1,0 +1,14 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: opensuse
+    tag: latest
+inputs:
+- name: ci
+- name: bundle
+run:
+  path: ci/cf-usb/tasks/service-image-link.sh
+params:
+  RELEASE_TOOL_URL: ~

--- a/cf-usb/tasks/service-publish.sh
+++ b/cf-usb/tasks/service-publish.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# This script publishes the cf-usb-sidecar bundle
+# Most arguments come from the task definition
+
+set -o errexit
+
+# Need to set up access to the appropriate repos
+eval "$(ssh-agent)"
+trap "ssh-agent -k" EXIT
+
+grep --null-data '^GITHUB_KEY=' /proc/self/environ \
+    | tail -c +12 \
+    | tr '\0' '\n' \
+    | ssh-add /dev/stdin
+unset GITHUB_KEY
+
+# Pick up the SSH host key
+ssh -o StrictHostKeyChecking=no -l git github.com <&- 2>&1 \
+    | grep "successfully authenticated"
+
+export SIDECAR_BUNDLE="$(cat bundle/url)"
+exec src/scripts/create_helm_charts_pr.sh

--- a/cf-usb/tasks/service-publish.yml
+++ b/cf-usb/tasks/service-publish.yml
@@ -1,0 +1,19 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: opensuse
+    tag: latest
+inputs:
+- name: src
+- name: ci
+- name: bundle
+run:
+  path: ci/cf-usb/tasks/service-publish.sh
+params:
+  SERVICE: ~
+  GITHUB_USER: ~
+  GITHUB_PASSWORD: ~
+  GITHUB_KEY: ~
+  GITHUB_ORGANIZATION: ~

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -40,7 +40,7 @@ HELM_PARAMS=(--set "env.DOMAIN=${DOMAIN}"
              --set "kube.external_ip=${external_ip}"
              --set "kube.auth=rbac")
 if [ -n "${KUBE_REGISTRY_HOSTNAME:-}" ]; then
-    HELM_PARAMS+=(--set "kube.registry.hostname=${KUBE_REGISTRY_HOSTNAME}")
+    HELM_PARAMS+=(--set "kube.registry.hostname=${KUBE_REGISTRY_HOSTNAME%/}")
 fi
 if [ -n "${KUBE_REGISTRY_USERNAME:-}" ]; then
     HELM_PARAMS+=(--set "kube.registry.username=${KUBE_REGISTRY_USERNAME}")


### PR DESCRIPTION
This adds a new (manually triggered) job which will display the URL to the tool to publish docker images to the production docker registry, as well as create a PR for the helm chart.