### PR TITLE
cf-usb: override docker registry / organization for SLE build

### DIFF
--- a/cf-usb/cf-usb.yaml
+++ b/cf-usb/cf-usb.yaml
@@ -256,6 +256,8 @@ jobs:
         GITHUB_TOKEN: ((charts-github-access-token))
         GITHUB_KEY: ((charts-github-private-key))
         GITHUB_ORGANIZATION: ((charts-github-org))
+        OVERRIDE_DOCKER_REGISTRY: ((charts-docker-registry))
+        OVERRIDE_DOCKER_ORGANIZATION: ((charts-docker-organization))
       input_mapping:
         bundle: s3.mysql
 - name: sidecar-postgres
@@ -362,6 +364,8 @@ jobs:
         GITHUB_TOKEN: ((charts-github-access-token))
         GITHUB_KEY: ((charts-github-private-key))
         GITHUB_ORGANIZATION: ((charts-github-org))
+        OVERRIDE_DOCKER_REGISTRY: ((charts-docker-registry))
+        OVERRIDE_DOCKER_ORGANIZATION: ((charts-docker-organization))
       input_mapping:
         bundle: s3.postgres
 - name: commit-sources-to-obs

--- a/cf-usb/config-production.yaml
+++ b/cf-usb/config-production.yaml
@@ -30,6 +30,8 @@ charts-github-org: SUSE
 charts-github-username: *github-username
 charts-github-access-token: *github-access-token
 charts-github-private-key: *github-private-key
+charts-docker-registry: ""
+charts-docker-organization: ""
 
 # Commit sources to obs
 commit-sources: false

--- a/cf-usb/config-sle-production-master.yaml
+++ b/cf-usb/config-sle-production-master.yaml
@@ -30,6 +30,8 @@ charts-github-username: *github-username
 charts-github-access-token: *github-access-token
 charts-github-private-key: *github-private-key
 charts-github-org: SUSE
+charts-docker-registry: *docker-public-registry
+charts-docker-organization: cap
 
 # Commit sources to obs
 commit-sources: true


### PR DESCRIPTION
When publishing releases, override the docker registry / organization to the production places (which would be the expected values after manual publishing).

Currently the openSUSE develop build still makes sense to go to the staging registry, because that's not production.

Depends on https://github.com/SUSE/cf-usb-sidecar/pull/22