### PR TITLE
Reworked version processing in the chart builder

### DIFF
--- a/cf-usb/tasks/service-build.sh
+++ b/cf-usb/tasks/service-build.sh
@@ -8,6 +8,10 @@ svcroot="${usbroot}/csm-extensions/services/dev-${SERVICE}"
 if test -z "${APP_VERSION_TAG:-}" ; then
     export APP_VERSION_TAG="$(cd "${usbroot}" && scripts/build_version.sh "APP_VERSION_TAG")"
 fi
+if test -z "${APP_VERSION:-}" ; then
+    # strip from first dash to end
+    export APP_VERSION="${APP_VERSION_TAG%%-*}"
+fi
 
 make -C "${svcroot}" build helm
 
@@ -24,7 +28,7 @@ cp "${svcroot}/Dockerfile"       docker-out/
 cp "${svcroot}/Dockerfile-setup" docker-out/
 cp "${svcroot}/Dockerfile-db"    docker-out/
 cp -r "${svcroot}/chart"         docker-out/
-sed -i "s@^\(version: \).*@\1${APP_VERSION_TAG}@" "${svcroot}/output/helm/Chart.yaml"
+sed -i "s@^\(version: \).*@\1${APP_VERSION}@" "${svcroot}/output/helm/Chart.yaml"
 
 echo "${APP_VERSION_TAG}" > docker-out/tag
 tar -czf helm-out/cf-usb-sidecar-${SERVICE}-${APP_VERSION_TAG}.tgz -C "${svcroot}/output/helm/" .


### PR DESCRIPTION
Put only the main version information into the chart.
The archive will still use the full version for its filename.

Ref: https://trello.com/c/u18ks0c3/632-2-sidecars-switch-tagging-of-current-builds
For the test pipeline see reference.
