### PR TITLE
2.9.0 secrets workaround

### DIFF
--- a/qa-pipelines/cap-qa-upgrades/cap-qa-upgrades.yml
+++ b/qa-pipelines/cap-qa-upgrades/cap-qa-upgrades.yml
@@ -66,14 +66,14 @@ jobs:
       CAP_INSTALL_VERSION: ((cap-opensuse-url))
     input_mapping:
       s3.scf-config: s3.scf-config-opensuse
-  - task: acceptance-tests-brain
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      TEST_NAME: acceptance-tests-brain
-      CAP_CHART: -opensuse
-      CAP_INSTALL_VERSION: ((cap-opensuse-url))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
+  # - task: acceptance-tests-brain
+  #   file: ci/qa-pipelines/tasks/run-test.yml
+  #   params:
+  #     TEST_NAME: acceptance-tests-brain
+  #     CAP_CHART: -opensuse
+  #     CAP_INSTALL_VERSION: ((cap-opensuse-url))
+  #   input_mapping:
+  #     s3.scf-config: s3.scf-config-opensuse
   # Do not run CATs. They are destructive
   - task: cf-upgrade
     file: ci/qa-pipelines/tasks/cf-upgrade.yml
@@ -146,14 +146,14 @@ jobs:
       CAP_INSTALL_VERSION: ((cap-sle-url))
     input_mapping:
       s3.scf-config: s3.scf-config-sles
-  - task: acceptance-tests-brain
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      TEST_NAME: acceptance-tests-brain
-      CAP_CHART: ""
-      CAP_INSTALL_VERSION: ((cap-sle-url))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
+  # - task: acceptance-tests-brain
+  #   file: ci/qa-pipelines/tasks/run-test.yml
+  #   params:
+  #     TEST_NAME: acceptance-tests-brain
+  #     CAP_CHART: ""
+  #     CAP_INSTALL_VERSION: ((cap-sle-url))
+  #   input_mapping:
+  #     s3.scf-config: s3.scf-config-sles
   # Do not run CATs. They are destructive
   - task: cf-upgrade
     file: ci/qa-pipelines/tasks/cf-upgrade.yml
@@ -226,14 +226,14 @@ jobs:
       CAP_INSTALL_VERSION: ((cap-opensuse-url))
     input_mapping:
       s3.scf-config: s3.scf-config-opensuse
-  - task: acceptance-tests-brain
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      TEST_NAME: acceptance-tests-brain
-      CAP_CHART: -opensuse
-      CAP_INSTALL_VERSION: ((cap-opensuse-url))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
+  # - task: acceptance-tests-brain
+  #   file: ci/qa-pipelines/tasks/run-test.yml
+  #   params:
+  #     TEST_NAME: acceptance-tests-brain
+  #     CAP_CHART: -opensuse
+  #     CAP_INSTALL_VERSION: ((cap-opensuse-url))
+  #   input_mapping:
+  #     s3.scf-config: s3.scf-config-opensuse
   # Do not run CATs. They are destructive
   - task: cf-upgrade
     file: ci/qa-pipelines/tasks/cf-upgrade.yml
@@ -306,14 +306,14 @@ jobs:
       CAP_INSTALL_VERSION: ((cap-sle-url))
     input_mapping:
       s3.scf-config: s3.scf-config-sles
-  - task: acceptance-tests-brain
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      TEST_NAME: acceptance-tests-brain
-      CAP_CHART: ""
-      CAP_INSTALL_VERSION: ((cap-sle-url))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
+  # - task: acceptance-tests-brain
+  #   file: ci/qa-pipelines/tasks/run-test.yml
+  #   params:
+  #     TEST_NAME: acceptance-tests-brain
+  #     CAP_CHART: ""
+  #     CAP_INSTALL_VERSION: ((cap-sle-url))
+  #   input_mapping:
+  #     s3.scf-config: s3.scf-config-sles
   # Do not run CATs. They are destructive
   - task: cf-upgrade
     file: ci/qa-pipelines/tasks/cf-upgrade.yml

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -168,7 +168,7 @@ fi
 
 if [[ ${SCALED_HA} == true ]]; then
   HELM_PARAMS+=(--set=sizing.routing_api.count=1)
-  HELM_PARAMS+=(--set=sizing.{api,cc-uploader,cc-worker,cf_usb,diego_access,diego_brain,doppler,loggregator,mysql,nats,router,syslog-adapter,syslog-rlp,tcp-router,mysql-proxy}.count=2)
+  HELM_PARAMS+=(--set=sizing.{api,cc_uploader,cc_worker,cf_usb,diego_access,diego_brain,doppler,loggregator,mysql,nats,router,syslog_adapter,syslog_rlp,tcp_router,mysql_proxy}.count=2)
   HELM_PARAMS+=(--set=sizing.{diego_api,diego-locket,diego_cell}.count=3)
 fi
 

--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -179,7 +179,7 @@ helm upgrade scf ${CAP_DIRECTORY}/helm/cf${CAP_CHART}/ \
     --set "env.UAA_HOST=${UAA_HOST}" \
     --set "env.UAA_PORT=${UAA_PORT}" \
     --set "secrets.UAA_CA_CERT=${CA_CERT}" \
-    --set "kube.secrets_generation_counter=$(date +%s)"\
+    --set "kube.secrets_generation_counter=2"\
     "${HELM_PARAMS[@]}"
 
 # Wait for CF namespace

--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -25,7 +25,7 @@ set +o allexport
 
 # Delete old test pods
 kubectl delete pod -n scf smoke-tests
-kubectl delete pod -n scf acceptance-tests-brain
+#kubectl delete pod -n scf acceptance-tests-brain
 
 unzip ${CAP_DIRECTORY}/scf-*.zip -d ${CAP_DIRECTORY}/
 
@@ -37,7 +37,7 @@ HELM_PARAMS=(--set "env.DOMAIN=${DOMAIN}"
              --set "kube.external_ips[0]=${external_ip}"
              --set "kube.auth=rbac")
 if [ -n "${KUBE_REGISTRY_HOSTNAME:-}" ]; then
-    HELM_PARAMS+=(--set "kube.registry.hostname=${KUBE_REGISTRY_HOSTNAME}")
+    HELM_PARAMS+=(--set "kube.registry.hostname=${KUBE_REGISTRY_HOSTNAME%/}")
 fi
 if [ -n "${KUBE_REGISTRY_USERNAME:-}" ]; then
     HELM_PARAMS+=(--set "kube.registry.username=${KUBE_REGISTRY_USERNAME}")
@@ -179,6 +179,7 @@ helm upgrade scf ${CAP_DIRECTORY}/helm/cf${CAP_CHART}/ \
     --set "env.UAA_HOST=${UAA_HOST}" \
     --set "env.UAA_PORT=${UAA_PORT}" \
     --set "secrets.UAA_CA_CERT=${CA_CERT}" \
+    --set "kube.secrets_generation_counter=$(date +%s)"\
     "${HELM_PARAMS[@]}"
 
 # Wait for CF namespace

--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -168,7 +168,7 @@ fi
 
 if [[ ${SCALED_HA} == true ]]; then
   HELM_PARAMS+=(--set=sizing.routing_api.count=1)
-  HELM_PARAMS+=(--set=sizing.{api,cc-uploader,cc-worker,cf_usb,diego_access,diego_brain,doppler,loggregator,mysql,nats,router,syslog-adapter,syslog-rlp,tcp-router,mysql-proxy}.count=2)
+  HELM_PARAMS+=(--set=sizing.{api,cc_uploader,cc_worker,cf_usb,diego_access,diego_brain,doppler,loggregator,mysql,nats,router,syslog_adapter,syslog_rlp,tcp_router,mysql_proxy}.count=2)
   HELM_PARAMS+=(--set=sizing.{diego_api,diego-locket,diego_cell}.count=3)
 fi
 


### PR DESCRIPTION
disable brain-tests for 2.8.0, remove trailing `/` from registry hostname, kube.secrets_generation_counter=2