### PR TITLE
Harts add upgrade lite pipeline

### DIFF
--- a/qa-pipelines/cap-qa-upgrades-lite/cap-qa-upgrades-lite.yml
+++ b/qa-pipelines/cap-qa-upgrades-lite/cap-qa-upgrades-lite.yml
@@ -1,0 +1,266 @@
+# Concourse pipeline to deploy and upgrade CAP
+
+resources:
+- name: ci
+  type: git
+  source:
+    uri: ((src-ci-repo))
+    branch: ((src-ci-branch))
+    paths:
+    - qa-pipelines/*
+    - sample-apps/*
+
+- name: s3.scf-config-opensuse
+  type: s3
+  source:
+    endpoint: ((s3-config-endpoint))
+    access_key_id: ((s3-config-access-key))
+    secret_access_key: ((s3-config-secret-key))
+    bucket: ((s3-config-bucket-opensuse))
+    regexp: ((s3-config-prefix-opensuse))scf-opensuse-(.*)\.zip$
+
+- name: s3.scf-config-sles
+  type: s3
+  source:
+    endpoint: ((s3-config-endpoint))
+    access_key_id: ((s3-config-access-key))
+    secret_access_key: ((s3-config-secret-key))
+    bucket: ((s3-config-bucket-sles))
+    regexp: ((s3-config-prefix-sles))scf-sle-(.*)\.zip$
+
+- name: pool.kube-hosts
+  type: pool
+  source:
+    uri: ((kube-pool-repo))
+    private_key: ((kube-pool-key))
+    branch: ((kube-pool-branch))
+    pool: ((kube-pool-pool))
+
+jobs:
+- name: cap-qa-upgrade-SA-openSUSE
+  plan:
+  - aggregate:
+    - get: ci
+    - get: s3.scf-config-opensuse
+      trigger: true
+    - put: pool.kube-hosts
+      params: {acquire: true}
+    on_failure:
+      put: pool.kube-hosts
+      params: {release: pool.kube-hosts}
+  - task: cf-deploy
+    file: ci/qa-pipelines/tasks/cf-deploy.yml
+    params:
+      CAP_CHART: -opensuse
+      HA: false
+      SCALED_HA: false
+      MAGIC_DNS_SERVICE: ((magic-dns-service))
+      CAP_INSTALL_VERSION: ((cap-opensuse-url))
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
+  - task: cf-smoke-tests
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      TEST_NAME: smoke-tests
+      CAP_CHART: -opensuse
+      CAP_INSTALL_VERSION: ((cap-opensuse-url))
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
+  - task: cf-upgrade
+    file: ci/qa-pipelines/tasks/cf-upgrade.yml
+    params:
+      CAP_CHART: -opensuse
+      HA: false
+      SCALED_HA: false
+      MAGIC_DNS_SERVICE: ((magic-dns-service))
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
+  - task: cf-smoke-tests
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      TEST_NAME: smoke-tests
+      CAP_CHART: -opensuse
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
+  # We intentionally don't put the teardown and pool release steps in an ensure
+  # block, so that when tests fail we have a chance of examining why things are
+  # failing.
+  - task: cf-teardown
+    file: ci/qa-pipelines/tasks/cf-teardown.yml
+  - put: pool.kube-hosts
+    params: {release: pool.kube-hosts}
+
+- name: cap-qa-upgrade-SA-SLES
+  plan:
+  - aggregate:
+    - get: ci
+    - get: s3.scf-config-sles
+      trigger: true
+    - put: pool.kube-hosts
+      params: {acquire: true}
+    on_failure:
+      put: pool.kube-hosts
+      params: {release: pool.kube-hosts}
+  - task: cf-deploy
+    file: ci/qa-pipelines/tasks/cf-deploy.yml
+    params:
+      KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
+      KUBE_REGISTRY_USERNAME: ((registry-username))
+      KUBE_REGISTRY_PASSWORD: ((registry-password))
+      KUBE_ORGANIZATION: ((organization))
+      CAP_CHART: ""
+      HA: false
+      SCALED_HA: false
+      MAGIC_DNS_SERVICE: ((magic-dns-service))
+      CAP_INSTALL_VERSION: ((cap-sle-url))
+    input_mapping:
+      s3.scf-config: s3.scf-config-sles
+  - task: cf-smoke-tests
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      TEST_NAME: smoke-tests
+      CAP_CHART: ""
+      CAP_INSTALL_VERSION: ((cap-sle-url))
+    input_mapping:
+      s3.scf-config: s3.scf-config-sles
+  - task: cf-upgrade
+    file: ci/qa-pipelines/tasks/cf-upgrade.yml
+    params:
+      KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
+      KUBE_REGISTRY_USERNAME: ((registry-username))
+      KUBE_REGISTRY_PASSWORD: ((registry-password))
+      KUBE_ORGANIZATION: ((organization))
+      CAP_CHART: ""
+      HA: false
+      SCALED_HA: false
+      MAGIC_DNS_SERVICE: ((magic-dns-service))
+    input_mapping:
+      s3.scf-config: s3.scf-config-sles
+  - task: cf-smoke-tests
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      TEST_NAME: smoke-tests
+      CAP_CHART: ""
+    input_mapping:
+      s3.scf-config: s3.scf-config-sles
+  # We intentionally don't put the teardown and pool release steps in an ensure
+  # block, so that when tests fail we have a chance of examining why things are
+  # failing.
+  - task: cf-teardown
+    file: ci/qa-pipelines/tasks/cf-teardown.yml
+  - put: pool.kube-hosts
+    params: {release: pool.kube-hosts}
+
+- name: cap-qa-upgrade-HA-openSUSE
+  plan:
+  - aggregate:
+    - get: ci
+    - get: s3.scf-config-opensuse
+      trigger: true
+    - put: pool.kube-hosts
+      params: {acquire: true}
+    on_failure:
+      put: pool.kube-hosts
+      params: {release: pool.kube-hosts}
+  - task: cf-deploy
+    file: ci/qa-pipelines/tasks/cf-deploy.yml
+    params:
+      CAP_CHART: -opensuse
+      HA: false
+      SCALED_HA: true
+      MAGIC_DNS_SERVICE: ((magic-dns-service))
+      CAP_INSTALL_VERSION: ((cap-opensuse-url))
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
+  - task: cf-smoke-tests
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      TEST_NAME: smoke-tests
+      CAP_CHART: -opensuse
+      CAP_INSTALL_VERSION: ((cap-opensuse-url))
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
+  - task: cf-upgrade
+    file: ci/qa-pipelines/tasks/cf-upgrade.yml
+    params:
+      CAP_CHART: -opensuse
+      HA: false
+      SCALED_HA: true
+      MAGIC_DNS_SERVICE: ((magic-dns-service))
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
+  - task: cf-smoke-tests
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      TEST_NAME: smoke-tests
+      CAP_CHART: -opensuse
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
+  # We intentionally don't put the teardown and pool release steps in an ensure
+  # block, so that when tests fail we have a chance of examining why things are
+  # failing.
+  - task: cf-teardown
+    file: ci/qa-pipelines/tasks/cf-teardown.yml
+  - put: pool.kube-hosts
+    params: {release: pool.kube-hosts}
+
+- name: cap-qa-upgrade-HA-SLES
+  plan:
+  - aggregate:
+    - get: ci
+    - get: s3.scf-config-sles
+      trigger: true
+    - put: pool.kube-hosts
+      params: {acquire: true}
+    on_failure:
+      put: pool.kube-hosts
+      params: {release: pool.kube-hosts}
+  - task: cf-deploy
+    file: ci/qa-pipelines/tasks/cf-deploy.yml
+    params:
+      KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
+      KUBE_REGISTRY_USERNAME: ((registry-username))
+      KUBE_REGISTRY_PASSWORD: ((registry-password))
+      KUBE_ORGANIZATION: ((organization))
+      CAP_CHART: ""
+      HA: false
+      SCALED_HA: true
+      MAGIC_DNS_SERVICE: ((magic-dns-service))
+      CAP_INSTALL_VERSION: ((cap-sle-url))
+    input_mapping:
+      s3.scf-config: s3.scf-config-sles
+  - task: cf-smoke-tests
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      TEST_NAME: smoke-tests
+      CAP_CHART: ""
+      CAP_INSTALL_VERSION: ((cap-sle-url))
+    input_mapping:
+      s3.scf-config: s3.scf-config-sles
+  - task: cf-upgrade
+    file: ci/qa-pipelines/tasks/cf-upgrade.yml
+    params:
+      KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
+      KUBE_REGISTRY_USERNAME: ((registry-username))
+      KUBE_REGISTRY_PASSWORD: ((registry-password))
+      KUBE_ORGANIZATION: ((organization))
+      CAP_CHART: ""
+      HA: false
+      SCALED_HA: true
+      MAGIC_DNS_SERVICE: ((magic-dns-service))
+    input_mapping:
+      s3.scf-config: s3.scf-config-sles
+  - task: cf-smoke-tests
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      TEST_NAME: smoke-tests
+      CAP_CHART: ""
+    input_mapping:
+      s3.scf-config: s3.scf-config-sles
+  # We intentionally don't put the teardown and pool release steps in an ensure
+  # block, so that when tests fail we have a chance of examining why things are
+  # failing.
+  - task: cf-teardown
+    file: ci/qa-pipelines/tasks/cf-teardown.yml
+  - put: pool.kube-hosts
+    params: {release: pool.kube-hosts}

--- a/qa-pipelines/cap-qa-upgrades-lite/config-provo.yml
+++ b/qa-pipelines/cap-qa-upgrades-lite/config-provo.yml
@@ -1,0 +1,1 @@
+../config-provo.yml

--- a/qa-pipelines/cap-qa-upgrades-lite/config-vancouver.yml
+++ b/qa-pipelines/cap-qa-upgrades-lite/config-vancouver.yml
@@ -1,0 +1,1 @@
+../config-vancouver.yml

--- a/qa-pipelines/cap-qa-upgrades-lite/set-pipeline-cap-upgrades-lite
+++ b/qa-pipelines/cap-qa-upgrades-lite/set-pipeline-cap-upgrades-lite
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+usage() {
+    cat <<EOF
+
+${0} [options] <config variant>
+
+The pipeline configuration file "cap-qa-upgrades-lite.yml" must exist.
+The configuration file "config-<config variant>.yml" must exist.
+
+Available options:
+    -h, --help          Print this help and exit
+    -p, --prefix=       Set additional pipeline prefix
+    -t, --target=       Set fly target concourse
+
+EOF
+}
+
+OPTS=$(getopt -o hp:t: --long help,prefix:,target: -- "$@")
+eval set -- "${OPTS}"
+
+prefix=""
+target=""
+secrets_file=""
+while true ; do
+    case "$1" in
+        -h|--help)   usage ; exit 0 ;;
+        -p|--prefix) prefix="${2%-}-" ; shift 2 ;;
+        -t|--target) target="${2}" ; shift 2 ;;
+        --)          shift ; break ;;
+        *)           printf "Internal error: unexpected arguments %s\n" "$*" >&2 ; exit 1 ;;
+    esac
+done
+
+if test -z "${1:-}" ; then
+    usage
+    exit 1
+fi
+pipeline_name="${prefix}cap-qa-upgrades-lite"
+pipeline_file="cap-qa-upgrades-lite.yml"
+vars_file="config-${1}.yml"
+
+if ! test -r "${pipeline_file}" ; then
+    usage >&2
+    printf "Failed to read pipeline configuration %s\n" "${pipeline_file}" >&2
+    exit 1
+fi
+
+if ! test -r "${vars_file}" ; then
+    usage >&2
+    if test -n "${1:-}" ; then
+        printf "Variables file %s is not readable\n" "${vars_file}" >&2
+    fi
+    exit 1
+fi
+
+if test -n "${CONCOURSE_SECRETS_FILE:-}"; then
+    if test -r "${CONCOURSE_SECRETS_FILE:-}" ; then
+        secrets_file="${CONCOURSE_SECRETS_FILE}"
+    else
+        printf "ERROR: Secrets file %s is not readable\n" "${CONCOURSE_SECRETS_FILE}" >&2
+        exit 2
+    fi
+fi
+
+fly \
+    ${target:+"--target=${target}"} \
+    set-pipeline \
+    --pipeline="${pipeline_name}" \
+    --config="${pipeline_file}" \
+    --load-vars-from=<(
+        # We concatenate the two vars files together so that the config vars can
+        # refer to secret vars correctly
+        ${secrets_file:+gpg --decrypt --batch ${secrets_file}} # Import secrets
+        sed '/^---$/d' < "${vars_file}"                        # Config vars
+    )
+fly \
+    ${target:+"--target=$target"} \
+    expose-pipeline \
+    --pipeline="${pipeline_name}"
+# fly \
+#     ${target:+"--target=$target"} \
+#     unpause-pipeline \
+#     --pipeline="${pipeline_name}"


### PR DESCRIPTION
This defines a pipeline which only runs smoke tests (no acceptance, brain, or usb tests), in order to accelerate testing of changes to the cf-upgrade task.

This branch builds on top of the branch in https://github.com/SUSE/cf-ci/pull/110 (and was used to test the changes there) so should only be merged after it