### PR TITLE
Fix reference to moved create-qa-config script

### DIFF
--- a/automation-scripts/prep-new-cluster.sh
+++ b/automation-scripts/prep-new-cluster.sh
@@ -60,4 +60,4 @@ fi
 
 echo "Ensure the following config contents are in the lockfile for your concourse pool kube resource:"
 echo "---"
-curl -sL "https://raw.githubusercontent.com/SUSE/cf-ci/master/automation-scripts/create-qa-config.sh" | bash 2>/dev/null | awk '/apiVersion/ { yaml=1 }  yaml { print }'
+curl -sL "https://raw.githubusercontent.com/SUSE/cf-ci/master/qa-tools/create-qa-config.sh" | bash 2>/dev/null | awk '/apiVersion/ { yaml=1 }  yaml { print }'


### PR DESCRIPTION
This script has moved into the `qa-tools/` directory, but
`automation-scripts/prep-new-cluster.sh` is still referencing the old
path