### PR TITLE
Promote version clusterrole/binding definitions away from alpha 

### DIFF
--- a/automation-scripts/nfs-provisioner/clusterrole.yaml
+++ b/automation-scripts/nfs-provisioner/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nfs-provisioner-runner
 rules:

--- a/automation-scripts/nfs-provisioner/clusterrolebinding.yaml
+++ b/automation-scripts/nfs-provisioner/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: run-nfs-provisioner
 subjects:


### PR DESCRIPTION
Merge Troy's commit which updates the apiVersion of the clusterrole and clusterrolebinding definitions for the NFS storageclass to `v1` (from `v1alpha`, which necessary for Kube <= 1.7.x)