### PR TITLE
New fissile releases only use statefulsets

### DIFF
--- a/qa-pipelines/tasks/usb-deploy.sh
+++ b/qa-pipelines/tasks/usb-deploy.sh
@@ -29,7 +29,7 @@ done
 
 
 get_internal_ca_cert() {
-  local generated_secrets_secret=$(kubectl get --namespace ${1} deploy -o json | jq -r '[.items[].spec.template.spec.containers[].env[] | select(.name == "INTERNAL_CA_CERT").valueFrom.secretKeyRef.name] | unique[]')
+  local generated_secrets_secret=$(kubectl get --namespace ${1} statefulset,deploy -o json | jq -r '[.items[].spec.template.spec.containers[].env[] | select(.name == "INTERNAL_CA_CERT").valueFrom.secretKeyRef.name] | unique[]')
   if [[ $(echo $generated_secrets_secret | wc -w) -ne 1 ]]; then
     echo "Internal cert or secret problem in ${1} namespace"
     return 1

--- a/qa-pipelines/tasks/usb-post-upgrade.sh
+++ b/qa-pipelines/tasks/usb-post-upgrade.sh
@@ -12,7 +12,7 @@ cf login -u admin -p changeme -o system
 # Temporary workaround for usb breakage after secret rotation
 echo "Update broker password after rotation:"
 CF_NAMESPACE=scf
-SECRET=$(kubectl get --namespace $CF_NAMESPACE deploy -o json | jq -r '[.items[].spec.template.spec.containers[].env[] | select(.name == "INTERNAL_CA_CERT").valueFrom.secretKeyRef.name] | unique[]')
+SECRET=$(kubectl get --namespace $CF_NAMESPACE statefulset,deploy -o json | jq -r '[.items[].spec.template.spec.containers[].env[] | select(.name == "INTERNAL_CA_CERT").valueFrom.secretKeyRef.name] | unique[]')
 USB_PASSWORD=$(kubectl get -n scf secret $SECRET -o jsonpath='{@.data.cf-usb-password}' | base64 -d)
 USB_ENDPOINT=$(cf curl /v2/service_brokers | jq -r '.resources[] | select(.entity.name=="usb").entity.broker_url')
 cf update-service-broker usb broker-admin "$USB_PASSWORD" "$USB_ENDPOINT"


### PR DESCRIPTION
The scripts that use `kubectl get deploy` won't work on SCF charts built with newer fissile because they don't create deployments any more.

`kubectl get` lets us get multiple things if they're comma separated, so this should be backwards compatible.