### PR TITLE
cf-usb-plugin: disable CGO

### DIFF
--- a/cf-usb-plugin/tasks/dist.yaml
+++ b/cf-usb-plugin/tasks/dist.yaml
@@ -5,6 +5,8 @@ image_resource:
   source:
     repository: golang
     tag: '1'
+params:
+  CGO_ENABLED: "0"
 inputs:
   - name: src
     path: src/github.com/SUSE/cf-usb-plugin


### PR DESCRIPTION
This creates a static binary that should be more compatible with other systems (e.g. alpine without libpthreads).