### PR TITLE
Use current branch for pipeline deploy

### DIFF
--- a/qa-pipelines/config-provo.yml
+++ b/qa-pipelines/config-provo.yml
@@ -2,7 +2,6 @@
 src-repo: https://github.com/SUSE/scf.git
 src-branch: develop
 src-ci-repo: https://github.com/SUSE/cf-ci.git
-src-ci-branch: master
 
 src-rails-example-repo: https://github.com/scf-samples/rails-example.git
 kube-pool-repo: git@github.com:SUSE/cf-ci-pools.git

--- a/qa-pipelines/qa-pipeline.yml
+++ b/qa-pipelines/qa-pipeline.yml
@@ -55,7 +55,7 @@ resources:
     pool: ((kube-pool-pool))
 
 jobs:
-- name: cap-qa-upgrade-SA-openSUSE
+- name: ((pipeline-name))-SA-openSUSE
   plan:
   - aggregate:
     - get: ci
@@ -156,7 +156,7 @@ jobs:
   - put: pool.kube-hosts
     params: {release: pool.kube-hosts}
 
-- name: cap-qa-upgrade-SA-SLES
+- name: ((pipeline-name))-SA-SLES
   plan:
   - aggregate:
     - get: ci
@@ -269,7 +269,7 @@ jobs:
   - put: pool.kube-hosts
     params: {release: pool.kube-hosts}
 
-- name: cap-qa-upgrade-HA-openSUSE
+- name: ((pipeline-name))-HA-openSUSE
   plan:
   - aggregate:
     - get: ci
@@ -370,7 +370,7 @@ jobs:
   - put: pool.kube-hosts
     params: {release: pool.kube-hosts}
 
-- name: cap-qa-upgrade-HA-SLES
+- name: ((pipeline-name))-HA-SLES
   plan:
   - aggregate:
     - get: ci

--- a/qa-pipelines/set-pipeline
+++ b/qa-pipelines/set-pipeline
@@ -126,6 +126,7 @@ fly \
     ${target:+"--target=${target}"} \
     set-pipeline \
     --pipeline="${pipeline_name}" \
+    --var pipeline-name="${pipeline_name}" \
     --config="${pipeline_file}" \
     --var src-ci-branch=${src_ci_branch} \
     --load-vars-from=<(

--- a/qa-pipelines/set-pipeline
+++ b/qa-pipelines/set-pipeline
@@ -15,14 +15,16 @@ Available options:
     -p, --prefix=       Set additional pipeline prefix
     --pool=provo        Pool to take pool config and kube config from. Default is 'provo' 
     -t, --target=       Set fly target concourse
+    -b, --branch=       Use a specific branch or tag. Defaults to the current branch
 
 EOF
 }
 
-OPTS=$(getopt -o hp:t: --long help,pool:,prefix:,target: -- "$@")
+OPTS=$(getopt -o hp:t:b: --long help,pool:,prefix:,target:,branch: -- "$@")
 eval set -- "${OPTS}"
 
 pool=provo
+src_ci_branch=$(git rev-parse --abbrev-ref HEAD)
 prefix=""
 target=""
 secrets_file=""
@@ -32,6 +34,7 @@ while true ; do
         -p|--prefix) prefix="${2%-}-" ; shift 2 ;;
         -t|--target) target="${2}" ; shift 2 ;;
         --pool)      pool="${2}" ; shift 2 ;;
+        -b|--branch) src_ci_branch="${2}" ; shift 2 ;;
         --)          shift ; break ;;
         *)           printf "Internal error: unexpected arguments %s\n" "$*" >&2 ; exit 1 ;;
     esac
@@ -77,6 +80,40 @@ if test -n "${CONCOURSE_SECRETS_FILE:-}"; then
     fi
 fi
 
+# Branch is assumed to be the current branch if not specified, but the concourse git
+# resource doesn't allow commit references to be used directly. 
+if [[ -z $src_ci_branch ]] ||
+    [[  $(echo $src_ci_branch | tr '[:upper:]' '[:lower:]') == head ]]; then
+  printf "Failed to determine ref for git resource to use.\n" >&2
+  printf "Checkout a branch or specify a branch/tag with '-b\n'" >&2
+  exit 1
+fi
+
+# Now that we have the branch/tag, check that it exists in the remote with the URL specified
+# in the config file's 'src_ci_repo'.
+
+src_ci_repo=$(
+  #Remove anchor references from vars file as they break parsing
+  grep -v '\*' $vars_file \
+  | ruby -r yaml -e "puts YAML.load(STDIN.read)['src-ci-repo']"
+)
+src_ci_remote=$(git remote -v | grep -F "$src_ci_repo (fetch)" | cut -f1 | head -1)
+
+# If a matching remote couldn't be found, create one
+if [[ -z $src_ci_remote ]]; then
+  src_ci_remote=${pool}-src-ci-repo
+  git remote add $src_ci_remote $src_ci_repo
+fi
+
+# Ensure we have the latest tag/branch updates from remote
+git fetch $src_ci_remote
+
+# Check that the tag/branch specified exists on the remote
+if ! git ls-remote --exit-code $src_ci_remote $src_ci_branch; then
+  printf "The branch/tag %s could not be found in repo %s\n" $src_ci_branch $src_ci_repo >&2
+  exit 1
+fi
+
 # We concatenate our secrets file, pipeline variables, preset file (which sets
 # 'enable' flags for each task needed for this pipeline deployment), and an
 # additional set of 'false' enable flags, for every flag which is not mentioned in
@@ -87,6 +124,7 @@ fly \
     set-pipeline \
     --pipeline="${pipeline_name}" \
     --config="${pipeline_file}" \
+    --var src-ci-branch=${src_ci_branch} \
     --load-vars-from=<(
         ${secrets_file:+gpg --decrypt --batch ${secrets_file}} # Import secrets
         sed '/^---$/d' < "${vars_file}"                        # Config vars

--- a/qa-pipelines/set-pipeline
+++ b/qa-pipelines/set-pipeline
@@ -114,6 +114,9 @@ if ! git ls-remote --exit-code $src_ci_remote $src_ci_branch; then
   exit 1
 fi
 
+# Append tag/branch name to pipeline name
+pipeline_name=${pipeline_name}-${src_ci_branch}
+
 # We concatenate our secrets file, pipeline variables, preset file (which sets
 # 'enable' flags for each task needed for this pipeline deployment), and an
 # additional set of 'false' enable flags, for every flag which is not mentioned in


### PR DESCRIPTION
No longer specify the branch in the config file. The user can specify it
when deploying (with the '-b' or '--branch' flags). Otherwise, the
set-pipeline script will take the name of the current branch. If the
branch doesn't exist on the remote, or the user is in a detached head,
provide appropriate output and exit