### PR TITLE
Add teardown timeout back to pipeline definition

### DIFF
--- a/qa-pipelines/pipeline-presets/cap-qa-deployment-lite.yml
+++ b/qa-pipelines/pipeline-presets/cap-qa-deployment-lite.yml
@@ -1,0 +1,5 @@
+---
+
+enable-cf-deploy: true
+enable-cf-smoke-tests: true
+enable-cf-teardown: true

--- a/qa-pipelines/qa-pipeline.yml
+++ b/qa-pipelines/qa-pipeline.yml
@@ -151,6 +151,7 @@ jobs:
   # failing.
   - task: cf-teardown
     file: ci/qa-pipelines/tasks/cf-teardown.yml
+    timeout: 1h
     params:
       ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
   - put: pool.kube-hosts
@@ -264,6 +265,7 @@ jobs:
   # failing.
   - task: cf-teardown
     file: ci/qa-pipelines/tasks/cf-teardown.yml
+    timeout: 1h
     params:
       ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
   - put: pool.kube-hosts
@@ -365,6 +367,7 @@ jobs:
   # failing.
   - task: cf-teardown
     file: ci/qa-pipelines/tasks/cf-teardown.yml
+    timeout: 1h
     params:
       ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
   - put: pool.kube-hosts
@@ -478,6 +481,7 @@ jobs:
   # failing.
   - task: cf-teardown
     file: ci/qa-pipelines/tasks/cf-teardown.yml
+    timeout: 1h
     params:
       ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
   - put: pool.kube-hosts


### PR DESCRIPTION
In commit 135c0bf511fd6a691fdf4d17546b148c3c2c90a9, we introduced a
timeout to the teardown of our cf-deploy teardown step definitions
because our teardowns would sometimes get stuck. This change was never
propagated to the other pipeline definitions due to oversight on our
part, so didn't make it into the unified pipeline definition (which was
based on the former upgrade pipeline definition).

In addition to copying this timeout back into the teardown steps, I've
added a deployments-lite preset for testing of a deploy, smoke, and
teardown.