### PR TITLE
Harts get domain from configmap

### DIFF
--- a/qa-pipelines/config-provo.yml
+++ b/qa-pipelines/config-provo.yml
@@ -27,5 +27,5 @@ organization: splatform
 
 magic-dns-service: omg.howdoi.website
 
-cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.8.0%2Bcf1.15.0.0.g5aa8b036-amd64.zip
+cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.10.1%2Bcf1.15.0.0.g647b2273-amd64.zip
 cap-opensuse-url: https://github.com/SUSE/scf/releases/download/2.8.0/scf-opensuse-2.8.0.cf1.15.0.0.g5aa8b036-amd64.zip

--- a/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
@@ -149,7 +149,6 @@ set -o allexport
 # the public IP (used for DOMAIN) will be taken from the floating IP or load balancer IP.
 external_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["internal-ip"]')
 public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"] // empty')
-public_ip=${public_ip:-$external_ip}
 
 # Domain for SCF. DNS for *.DOMAIN must point to the same kube node
 # referenced by external_ip.

--- a/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
@@ -141,3 +141,21 @@ set_scf_sizing_params() {
         HELM_PARAMS+=(--set=sizing.{diego_api,diego_locket,diego_cell}.count=3)
     fi
 }
+
+set -o allexport
+
+# The internal/external and public IP addresses are now taken from the configmap set by prep-new-cluster
+# The external_ip is set to the internal ip of a worker node. When running on openstack or azure, 
+# the public IP (used for DOMAIN) will be taken from the floating IP or load balancer IP.
+external_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["internal-ip"]')
+public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"] // empty')
+public_ip=${public_ip:-$external_ip}
+
+# Domain for SCF. DNS for *.DOMAIN must point to the same kube node
+# referenced by external_ip.
+DOMAIN=${public_ip}.${MAGIC_DNS_SERVICE}
+
+# UAA host/port that SCF will talk to.
+UAA_HOST=uaa.${DOMAIN}
+
+set +o allexport

--- a/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# Set kube config from pool
+mkdir -p /root/.kube/
+cp pool.kube-hosts/metadata /root/.kube/config
+
+UAA_PORT=2793
+
+CF_NAMESPACE=scf
+UAA_NAMESPACE=uaa
+CAP_DIRECTORY=s3.scf-config
+
+if [ -n "${CAP_INSTALL_VERSION:-}" ]; then
+    # For pre-upgrade deploys
+    curl ${CAP_INSTALL_VERSION} -Lo cap-install-version.zip
+    export CAP_DIRECTORY=cap-install-version
+    unzip ${CAP_DIRECTORY}.zip -d ${CAP_DIRECTORY}/
+else
+    unzip ${CAP_DIRECTORY}/scf-*.zip -d ${CAP_DIRECTORY}/
+fi
+
+# Check that the kube of the cluster is reasonable
+bash ${CAP_DIRECTORY}/kube-ready-state-check.sh kube
+
+PROVISIONER=$(kubectl get storageclasses persistent -o "jsonpath={.provisioner}")
+
+# Password for SCF to authenticate with UAA
+UAA_ADMIN_CLIENT_SECRET="$(head -c32 /dev/urandom | base64)"
+
+# Wait until CF namespaces are ready
+is_namespace_ready() {
+    local namespace="$1"
+
+    # Create regular expression to match active_passive_pods
+    # These are scaled services which are expected to only have one pod listed as ready
+    local active_passive_pod_regex='^diego-api$|^diego-brain$|^routing-api$'
+    local active_passive_role_count=$(awk -F '|' '{ print NF }' <<< "${active_passive_pod_regex}")
+
+    # Get the container name and status for each pod in two columns
+    # The name here will be the role name, not the pod name, e.g. 'diego-brain' not 'diego-brain-1'
+    local active_passive_pod_status=$(2>/dev/null kubectl get pods --namespace=${namespace} --output=custom-columns=':.status.containerStatuses[].name,:.status.containerStatuses[].ready' \
+        | awk '$1 ~ '"/${active_passive_pod_regex}/")
+
+    # Check that the number of containers which are ready is equal to the number of active passive roles
+    if [[ -n $active_passive_pod_status ]] && [[ $(echo "$active_passive_pod_status" | grep true | wc -l) -ne ${active_passive_role_count} ]]; then
+        return 1
+    fi
+
+    # Finally, check that all pods which do not match the active_passive_pod_regex are ready
+    [[ true == $(2>/dev/null kubectl get pods --namespace=${namespace} --output=custom-columns=':.status.containerStatuses[].name,:.status.containerStatuses[].ready' \
+        | awk '$1 !~ '"/${active_passive_pod_regex}/ { print \$2 }" \
+        | sed '/^ *$/d' \
+        | sort \
+        | uniq) ]]
+}
+
+wait_for_namespace() {
+    local namespace="$1"
+    start=$(date +%s)
+    for (( i = 0  ; i < 960 ; i ++ )) ; do
+        if is_namespace_ready "${namespace}" ; then
+            break
+        fi
+        now=$(date +%s)
+        printf "\rWaiting for %s at %s (%ss)..." "${namespace}" "$(date --rfc-2822)" $((${now} - ${start}))
+        sleep 10
+    done
+    now=$(date +%s)
+    printf "\rDone waiting for %s at %s (%ss)\n" "${namespace}" "$(date --rfc-2822)" $((${now} - ${start}))
+    kubectl get pods --namespace="${namespace}"
+    if ! is_namespace_ready "${namespace}" ; then
+        printf "Namespace %s is still pending\n" "${namespace}"
+        exit 1
+    fi
+}
+
+function semver_is_gte() {
+  # Returns successfully if the left-hand semver is greater than or equal to the right-hand semver
+  # lexical comparison doesn't work on semvers, e.g. 10.0.0 > 2.0.0
+  [[ "$(echo -e "$1\n$2" |
+        sort -t '.' -k 1,1 -k 2,2 -k 3,3 -g |
+        tail -n 1
+    )" == $1 ]]
+}
+
+# Get the version of the helm chart for uaa
+helm_chart_version() { grep "^version:"  ${CAP_DIRECTORY}/helm/uaa${CAP_CHART}/Chart.yaml  | sed 's/version: *//g' ; }
+
+generated_secrets_secret() { kubectl get --namespace "${UAA_NAMESPACE}" secrets --output "custom-columns=:.metadata.name" | grep -F "secrets-$(helm_chart_version)-" | sort | tail -n 1 ; }
+
+get_internal_ca_cert() {
+    local uaa_secret_name=$(generated_secrets_secret)
+    kubectl get secret ${uaa_secret_name} \
+      --namespace "${UAA_NAMESPACE}" \
+      -o jsonpath="{.data['internal-ca-cert']}" \
+      | base64 -d
+}
+
+set_helm_params() {
+    HELM_PARAMS=(--set "env.DOMAIN=${DOMAIN}"
+                 --set "secrets.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}"
+                 --set "kube.external_ips[0]=${external_ip}"
+                 --set "kube.auth=rbac")
+
+    if [ -n "${KUBE_REGISTRY_HOSTNAME:-}" ]; then
+        HELM_PARAMS+=(--set "kube.registry.hostname=${KUBE_REGISTRY_HOSTNAME%/}")
+    fi
+    if [ -n "${KUBE_REGISTRY_USERNAME:-}" ]; then
+        HELM_PARAMS+=(--set "kube.registry.username=${KUBE_REGISTRY_USERNAME}")
+    fi
+    if [ -n "${KUBE_REGISTRY_PASSWORD:-}" ]; then
+        HELM_PARAMS+=(--set "kube.registry.password=${KUBE_REGISTRY_PASSWORD}")
+    fi
+    if [ -n "${KUBE_ORGANIZATION:-}" ]; then
+        HELM_PARAMS+=(--set "kube.organization=${KUBE_ORGANIZATION}")
+    fi
+}
+
+set_uaa_sizing_params() {
+    if [[ ${HA} == true ]]; then
+        if semver_is_gte $(helm_chart_version) 2.10.1; then
+            HELM_PARAMS+=(--set=config.HA=true)
+        else
+            HELM_PARAMS+=(--set=sizing.HA=true)
+        fi
+    elif [[ ${SCALED_HA} == true ]]; then
+        HELM_PARAMS+=(--set=sizing.{uaa,mysql,mysql_proxy}.count=3)
+    fi
+}
+
+set_scf_sizing_params() {
+    if [[ ${HA} == true ]]; then
+        if semver_is_gte $(helm_chart_version) 2.10.1; then
+            HELM_PARAMS+=(--set=config.HA=true)
+        else
+            HELM_PARAMS+=(--set=sizing.HA=true)
+        fi
+    elif [[ ${SCALED_HA} == true ]]; then
+        HELM_PARAMS+=(--set=sizing.routing_api.count=1)
+        HELM_PARAMS+=(--set=sizing.{api,cc_uploader,cc_worker,cf_usb,diego_access,diego_brain,doppler,loggregator,mysql,nats,router,syslog_adapter,syslog_rlp,tcp_router,mysql_proxy}.count=2)
+        HELM_PARAMS+=(--set=sizing.{diego_api,diego_locket,diego_cell}.count=3)
+    fi
+}

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -8,132 +8,30 @@ fi
 
 set -o nounset
 
-# Set kube config from pool
-mkdir -p /root/.kube/
-cp  pool.kube-hosts/metadata /root/.kube/config
+source "ci/qa-pipelines/tasks/cf-deploy-upgrade-common.sh"
 
 set -o allexport
+
 # The IP address assigned to the first kubelet node.
 external_ip=$(kubectl get nodes -o json | jq -er '.items[] | select(.spec.unschedulable == true | not) | .metadata.annotations["flannel.alpha.coreos.com/public-ip"]//empty'| head -n1)
+
 # Domain for SCF. DNS for *.DOMAIN must point to the kube node's
 # external ip. This must match the value passed to the
 # cert-generator.sh script.
 DOMAIN=${external_ip}.${MAGIC_DNS_SERVICE}
-# Password for SCF to authenticate with UAA
-UAA_ADMIN_CLIENT_SECRET="$(head -c32 /dev/urandom | base64)"
+
 # UAA host/port that SCF will talk to.
 UAA_HOST=uaa.${external_ip}.${MAGIC_DNS_SERVICE}
-UAA_PORT=2793
 
-CF_NAMESPACE=scf
-UAA_NAMESPACE=uaa
-CAP_DIRECTORY=s3.scf-config
 set +o allexport
 
-# For upgrades tests
-if [ -n "${CAP_INSTALL_VERSION:-}" ]; then
-    curl ${CAP_INSTALL_VERSION} -Lo cap-install-version.zip
-    export CAP_DIRECTORY=cap-install-version
-    unzip ${CAP_DIRECTORY}.zip -d ${CAP_DIRECTORY}/
-else
-    unzip ${CAP_DIRECTORY}/scf-*.zip -d ${CAP_DIRECTORY}/
-fi
+set_helm_params # Sets HELM_PARAMS
+set_uaa_sizing_params # Adds uaa sizing params to HELM_PARAMS
 
-# Get the version of the helm chart for uaa
-helm_chart_version() { grep "^version:"  ${CAP_DIRECTORY}/helm/uaa${CAP_CHART}/Chart.yaml  | sed 's/version: *//g' ; }
-
-function semver_is_gte() {
-  # Returns successfully if the left-hand semver is greater than or equal to the right-hand semver
-  # lexical comparison doesn't work on semvers, e.g. 10.0.0 > 2.0.0
-  [[ "$(echo -e "$1\n$2" |
-        sort -t '.' -k 1,1 -k 2,2 -k 3,3 -g |
-        tail -n 1
-    )" == $1 ]]
-}
-
-USER_PROVIDED_VALUES_KEY=secrets
-
-# Check that the kube of the cluster is reasonable
-bash ${CAP_DIRECTORY}/kube-ready-state-check.sh kube
-
-HELM_PARAMS=(--set "env.DOMAIN=${DOMAIN}"
-             --set "${USER_PROVIDED_VALUES_KEY}.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}"
-             --set "kube.external_ips[0]=${external_ip}"
-             --set "kube.auth=rbac")
-
-if [ -n "${KUBE_REGISTRY_HOSTNAME:-}" ]; then
-    HELM_PARAMS+=(--set "kube.registry.hostname=${KUBE_REGISTRY_HOSTNAME%/}")
-fi
-if [ -n "${KUBE_REGISTRY_USERNAME:-}" ]; then
-    HELM_PARAMS+=(--set "kube.registry.username=${KUBE_REGISTRY_USERNAME}")
-fi
-if [ -n "${KUBE_REGISTRY_PASSWORD:-}" ]; then
-    HELM_PARAMS+=(--set "kube.registry.password=${KUBE_REGISTRY_PASSWORD}")
-fi
-if [ -n "${KUBE_ORGANIZATION:-}" ]; then
-   HELM_PARAMS+=(--set "kube.organization=${KUBE_ORGANIZATION}")
-fi
-
-# Wait until CF namespaces are ready
-is_namespace_ready() {
-    local namespace="$1"
-
-    # Create regular expression to match active_passive_pods
-    # These are scaled services which are expected to only have one pod listed as ready
-    local active_passive_pod_regex='^diego-api$|^diego-brain$|^routing-api$'
-    local active_passive_role_count=$(awk -F '|' '{ print NF }' <<< "${active_passive_pod_regex}")
-
-    # Get the container name and status for each pod in two columns
-    # The name here will be the role name, not the pod name, e.g. 'diego-brain' not 'diego-brain-1'
-    local active_passive_pod_status=$(2>/dev/null kubectl get pods --namespace=${namespace} --output=custom-columns=':.status.containerStatuses[].name,:.status.containerStatuses[].ready' \
-        | awk '$1 ~ '"/${active_passive_pod_regex}/")
-
-    # Check that the number of containers which are ready is equal to the number of active passive roles 
-    if [[ -n $active_passive_pod_status ]] && [[ $(echo "$active_passive_pod_status" | grep true | wc -l) -ne ${active_passive_role_count} ]]; then
-        return 1
-    fi
-
-    # Finally, check that all pods which do not match the active_passive_pod_regex are ready
-    [[ true == $(2>/dev/null kubectl get pods --namespace=${namespace} --output=custom-columns=':.status.containerStatuses[].name,:.status.containerStatuses[].ready' \
-        | awk '$1 !~ '"/${active_passive_pod_regex}/ { print \$2 }" \
-        | sed '/^ *$/d' \
-        | sort \
-        | uniq) ]]
-}
-
-wait_for_namespace() {
-    local namespace="$1"
-    start=$(date +%s)
-    for (( i = 0  ; i < 960 ; i ++ )) ; do
-        if is_namespace_ready "${namespace}" ; then
-            break
-        fi
-        now=$(date +%s)
-        printf "\rWaiting for %s at %s (%ss)..." "${namespace}" "$(date --rfc-2822)" $((${now} - ${start}))
-        sleep 10
-    done
-    now=$(date +%s)
-    printf "\rDone waiting for %s at %s (%ss)\n" "${namespace}" "$(date --rfc-2822)" $((${now} - ${start}))
-    kubectl get pods --namespace="${namespace}"
-    if ! is_namespace_ready "${namespace}" ; then
-        printf "Namespace %s is still pending\n" "${namespace}"
-        exit 1
-    fi 
-}
-
-PROVISIONER=$(kubectl get storageclasses persistent -o "jsonpath={.provisioner}")
 # Deploy UAA
 kubectl create namespace "${UAA_NAMESPACE}"
 if [[ ${PROVISIONER} == kubernetes.io/rbd ]]; then
     kubectl get secret -o yaml ceph-secret-admin | sed "s/namespace: default/namespace: ${UAA_NAMESPACE}/g" | kubectl create -f -
-fi
-
-if [[ ${HA} == true ]]; then
-  HELM_PARAMS+=(--set=sizing.HA=true)
-fi
-
-if [[ ${SCALED_HA} == true ]]; then
-  HELM_PARAMS+=(--set=sizing.{uaa,mysql,mysql_proxy}.count=3)
 fi
 
 helm install ${CAP_DIRECTORY}/helm/uaa${CAP_CHART}/ \
@@ -145,43 +43,25 @@ helm install ${CAP_DIRECTORY}/helm/uaa${CAP_CHART}/ \
 # Wait for UAA namespace
 wait_for_namespace "${UAA_NAMESPACE}"
 
-
-generated_secrets_secret() { kubectl get --namespace "${UAA_NAMESPACE}" secrets --output "custom-columns=:.metadata.name" | grep -F "secrets-$(helm_chart_version)-" | sort | tail -n 1 ; }
-get_internal_ca_cert() {
-    local uaa_secret_name
-    uaa_secret_name=$(generated_secrets_secret)
-    kubectl get secret ${uaa_secret_name} \
-      --namespace "${UAA_NAMESPACE}" \
-      -o jsonpath="{.data['internal-ca-cert']}" \
-      | base64 -d 
-}
-
+# Deploy CF
 CA_CERT="$(get_internal_ca_cert)"
 
-# Deploy CF
+set_helm_params # Resets HELM_PARAMS
+set_scf_sizing_params # Adds scf sizing params to HELM_PARAMS
+
 kubectl create namespace "${CF_NAMESPACE}"
 if [[ ${PROVISIONER} == kubernetes.io/rbd ]]; then
     kubectl get secret -o yaml ceph-secret-admin | sed "s/namespace: default/namespace: ${CF_NAMESPACE}/g" | kubectl create -f -
-fi
-
-if [[ ${HA} == true ]]; then
-  HELM_PARAMS+=(--set=sizing.HA=true)
-fi
-
-if [[ ${SCALED_HA} == true ]]; then
-  HELM_PARAMS+=(--set=sizing.routing_api.count=1)
-  HELM_PARAMS+=(--set=sizing.{api,cc_uploader,cc_worker,cf_usb,diego_access,diego_brain,doppler,loggregator,mysql,nats,router,syslog_adapter,syslog_rlp,tcp_router,mysql_proxy}.count=2)
-  HELM_PARAMS+=(--set=sizing.{diego_api,diego_locket,diego_cell}.count=3)
 fi
 
 helm install ${CAP_DIRECTORY}/helm/cf${CAP_CHART}/ \
     --namespace "${CF_NAMESPACE}" \
     --name scf \
     --timeout 600 \
-    --set "${USER_PROVIDED_VALUES_KEY}.CLUSTER_ADMIN_PASSWORD=${CLUSTER_ADMIN_PASSWORD:-changeme}" \
+    --set "secrets.CLUSTER_ADMIN_PASSWORD=${CLUSTER_ADMIN_PASSWORD:-changeme}" \
     --set "env.UAA_HOST=${UAA_HOST}" \
     --set "env.UAA_PORT=${UAA_PORT}" \
-    --set "${USER_PROVIDED_VALUES_KEY}.UAA_CA_CERT=${CA_CERT}" \
+    --set "secrets.UAA_CA_CERT=${CA_CERT}" \
     "${HELM_PARAMS[@]}"
 
 # Wait for CF namespace

--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -8,17 +8,6 @@ fi
 
 source "ci/qa-pipelines/tasks/cf-deploy-upgrade-common.sh"
 
-set -o allexport
-
-# Domain for SCF, taken from the api pod
-DOMAIN=$(kubectl get pods -o json --namespace ${CF_NAMESPACE} api-0 | jq -r  '.spec.containers[0].env[] |  select(.name == "DOMAIN").value')
-external_ip=${DOMAIN%.${MAGIC_DNS_SERVICE}}
-
-# UAA host/port that SCF will talk to.
-UAA_HOST=uaa.${DOMAIN}
-
-set +o allexport
-
 # Delete old test pods
 kubectl delete pod -n scf smoke-tests
 #kubectl delete pod -n scf acceptance-tests-brain

--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -6,103 +6,22 @@ if [[ $ENABLE_CF_UPGRADE != true ]]; then
   exit 0
 fi
 
-# Set kube config from pool
-mkdir -p /root/.kube/
-cp  pool.kube-hosts/metadata /root/.kube/config
+source "ci/qa-pipelines/tasks/cf-deploy-upgrade-common.sh"
 
 set -o allexport
 
-CF_NAMESPACE=scf
-UAA_NAMESPACE=uaa
 # Domain for SCF, taken from the api pod
 DOMAIN=$(kubectl get pods -o json --namespace ${CF_NAMESPACE} api-0 | jq -r  '.spec.containers[0].env[] |  select(.name == "DOMAIN").value')
 external_ip=${DOMAIN%.${MAGIC_DNS_SERVICE}}
-# Password for SCF to authenticate with UAA
-UAA_ADMIN_CLIENT_SECRET="$(head -c32 /dev/urandom | base64)"
+
 # UAA host/port that SCF will talk to.
 UAA_HOST=uaa.${DOMAIN}
-UAA_PORT=2793
 
-CF_NAMESPACE=scf
-UAA_NAMESPACE=uaa
-
-CAP_DIRECTORY=s3.scf-config
 set +o allexport
 
 # Delete old test pods
 kubectl delete pod -n scf smoke-tests
 #kubectl delete pod -n scf acceptance-tests-brain
-
-unzip ${CAP_DIRECTORY}/scf-*.zip -d ${CAP_DIRECTORY}/
-
-# Check that the kube of the cluster is reasonable
-bash ${CAP_DIRECTORY}/kube-ready-state-check.sh kube
-
-HELM_PARAMS=(--set "env.DOMAIN=${DOMAIN}"
-             --set "secrets.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}"
-             --set "kube.external_ips[0]=${external_ip}"
-             --set "kube.auth=rbac")
-if [ -n "${KUBE_REGISTRY_HOSTNAME:-}" ]; then
-    HELM_PARAMS+=(--set "kube.registry.hostname=${KUBE_REGISTRY_HOSTNAME%/}")
-fi
-if [ -n "${KUBE_REGISTRY_USERNAME:-}" ]; then
-    HELM_PARAMS+=(--set "kube.registry.username=${KUBE_REGISTRY_USERNAME}")
-fi
-if [ -n "${KUBE_REGISTRY_PASSWORD:-}" ]; then
-    HELM_PARAMS+=(--set "kube.registry.password=${KUBE_REGISTRY_PASSWORD}")
-fi
-if [ -n "${KUBE_ORGANIZATION:-}" ]; then
-   HELM_PARAMS+=(--set "kube.organization=${KUBE_ORGANIZATION}")
-fi
-
-# Wait until CF namespaces are ready
-is_namespace_ready() {
-    local namespace="$1"
-
-    # Create regular expression to match active_passive_pods
-    # These are scaled services which are expected to only have one pod listed as ready
-    local active_passive_pod_regex='^diego-api$|^diego-brain$|^routing-api$'
-    local active_passive_role_count=$(awk -F '|' '{ print NF }' <<< "${active_passive_pod_regex}")
-
-    # Get the container name and status for each pod in two columns
-    # The name here will be the role name, not the pod name, e.g. 'diego-brain' not 'diego-brain-1'
-    local active_passive_pod_status=$(2>/dev/null kubectl get pods --namespace=${namespace} --output=custom-columns=':.status.containerStatuses[].name,:.status.containerStatuses[].ready' \
-        | awk '$1 ~ '"/${active_passive_pod_regex}/")
-
-    # Check that the number of containers which are ready is equal to the number of active passive roles 
-    if [[ -n $active_passive_pod_status ]] && [[ $(echo "$active_passive_pod_status" | grep true | wc -l) -ne ${active_passive_role_count} ]]; then
-        return 1
-    fi
-
-    # Finally, check that all pods which do not match the active_passive_pod_regex are ready
-    [[ true == $(2>/dev/null kubectl get pods --namespace=${namespace} --output=custom-columns=':.status.containerStatuses[].name,:.status.containerStatuses[].ready' \
-        | awk '$1 !~ '"/${active_passive_pod_regex}/ { print \$2 }" \
-        | sed '/^ *$/d' \
-        | sort \
-        | uniq) ]]
-}
-
-wait_for_namespace() {
-    local namespace="$1"
-    start=$(date +%s)
-    for (( i = 0  ; i < 960 ; i ++ )) ; do
-        if is_namespace_ready "${namespace}" ; then
-            break
-        fi
-        now=$(date +%s)
-        printf "\rWaiting for %s at %s (%ss)..." "${namespace}" "$(date --rfc-2822)" $((${now} - ${start}))
-        sleep 10
-    done
-    now=$(date +%s)
-    printf "\rDone waiting for %s at %s (%ss)\n" "${namespace}" "$(date --rfc-2822)" $((${now} - ${start}))
-    kubectl get pods --namespace="${namespace}"
-    if ! is_namespace_ready "${namespace}" ; then
-        printf "Namespace %s is still pending\n" "${namespace}"
-        exit 1
-    fi 
-}
-
-PROVISIONER=$(kubectl get storageclasses persistent -o "jsonpath={.provisioner}")
 
 # monitor_url takes a URL argument and a path to a log file
 # This will time out after 3 hours. Until then, repeatedly curl the URL with a 1-second wait period, and log the response
@@ -145,14 +64,8 @@ monitor_url() {
 monitor_file=$(mktemp -d)/downtime.log
 monitor_url "http://go-env.${DOMAIN}" "${monitor_file}" &
 
-# Upgrade UAA
-if [[ ${HA} == true ]]; then
-  HELM_PARAMS+=(--set=sizing.HA=true)
-fi
-
-if [[ ${SCALED_HA} == true ]]; then
-  HELM_PARAMS+=(--set=sizing.{uaa,mysql,mysql_proxy}.count=3)
-fi
+set_helm_params # Sets HELM_PARAMS
+set_uaa_sizing_params # Adds uaa sizing params to HELM_PARAMS
 
 helm upgrade uaa ${CAP_DIRECTORY}/helm/uaa${CAP_CHART}/ \
     --namespace "${UAA_NAMESPACE}" \
@@ -162,29 +75,11 @@ helm upgrade uaa ${CAP_DIRECTORY}/helm/uaa${CAP_CHART}/ \
 # Wait for UAA namespace
 wait_for_namespace "${UAA_NAMESPACE}"
 
-# Get the version of the helm chart for uaa
-helm_chart_version() { grep "^version:"  ${CAP_DIRECTORY}/helm/uaa${CAP_CHART}/Chart.yaml  | sed 's/version: *//g' ; }
-generated_secrets_secret() { kubectl get --namespace "${UAA_NAMESPACE}" secrets --output "custom-columns=:.metadata.name" | grep -F "secrets-$(helm_chart_version)-" | sort | tail -n 1 ; }
-get_internal_ca_cert() {
-    local uaa_secret_name=$(generated_secrets_secret)
-    kubectl get secret ${uaa_secret_name} \
-      --namespace "${UAA_NAMESPACE}" \
-      -o jsonpath="{.data['internal-ca-cert']}" \
-      | base64 -d
-}
-
+# Deploy CF
 CA_CERT="$(get_internal_ca_cert)"
 
-# Upgrade CF
-if [[ ${HA} == true ]]; then
-  HELM_PARAMS+=(--set=sizing.HA=true)
-fi
-
-if [[ ${SCALED_HA} == true ]]; then
-  HELM_PARAMS+=(--set=sizing.routing_api.count=1)
-  HELM_PARAMS+=(--set=sizing.{api,cc_uploader,cc_worker,cf_usb,diego_access,diego_brain,doppler,loggregator,mysql,nats,router,syslog_adapter,syslog_rlp,tcp_router,mysql_proxy}.count=2)
-  HELM_PARAMS+=(--set=sizing.{diego_api,diego_locket,diego_cell}.count=3)
-fi
+set_helm_params # Resets HELM_PARAMS
+set_scf_sizing_params # Adds scf sizing params to HELM_PARAMS
 
 helm upgrade scf ${CAP_DIRECTORY}/helm/cf${CAP_CHART}/ \
     --namespace "${CF_NAMESPACE}" \


### PR DESCRIPTION
Uses `cap-values` configmap to get information for `external_ips` and `DOMAIN` when deploying CAP. This will be set by the `prep-new-cluster.sh` script in the future (which will be compatible with CaaSP2, CaaSP3, Azure, and Openstack), but for now this can be added manually with a command like the following: `kubectl create configmap -n kube-system cap-values --from-literal=internal-ip=172.... --from-literal=public-ip=10....`

Builds on top of https://github.com/SUSE/cf-ci/pull/123