### PR TITLE
Filter out secret-generation pod in readiness check

### DIFF
--- a/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
@@ -48,6 +48,7 @@ is_namespace_ready() {
 
     # Finally, check that all pods which do not match the active_passive_pod_regex are ready
     [[ true == $(2>/dev/null kubectl get pods --namespace=${namespace} --output=custom-columns=':.status.containerStatuses[].name,:.status.containerStatuses[].ready' \
+        | grep -v secret-generation \
         | awk '$1 !~ '"/${active_passive_pod_regex}/ { print \$2 }" \
         | sed '/^ *$/d' \
         | sort \


### PR DESCRIPTION
This is now listed with the new kubectl client version, since
custom-columns seems to override show-all=false. Previously it would
respect --show-all=false and not list completed pods without `-a`