### PR TITLE
Also filter out post-deployment in readiness check

### DIFF
--- a/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
@@ -48,7 +48,7 @@ is_namespace_ready() {
 
     # Finally, check that all pods which do not match the active_passive_pod_regex are ready
     [[ true == $(2>/dev/null kubectl get pods --namespace=${namespace} --output=custom-columns=':.status.containerStatuses[].name,:.status.containerStatuses[].ready' \
-        | grep -v secret-generation \
+        | grep -vE 'secret-generation|post-deployment' \
         | awk '$1 !~ '"/${active_passive_pod_regex}/ { print \$2 }" \
         | sed '/^ *$/d' \
         | sort \


### PR DESCRIPTION
Added another commit to the "fix-readiness-check" branch because the post-deployment pod needs to be filtered out for the scf namespace as well.