### PR TITLE
Delete resources key from test manifests

### DIFF
--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -51,8 +51,10 @@ kube_overrides() {
                     env['valueFrom']['secretKeyRef']['name'] = '$generated_secrets_secret' 
                 end
             end
+            container.delete "resources"
         end
         puts obj.to_json
+
 EOF
 }
 


### PR DESCRIPTION
Setting 'cpu' here causes issues with running tests on AKS