### PR TITLE
Harts aks deploy improvements

### DIFF
--- a/qa-tools/cluster-admin.yaml
+++ b/qa-tools/cluster-admin.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: cluster-admin
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-system:default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-system 

--- a/qa-tools/deploy-aks.sh
+++ b/qa-tools/deploy-aks.sh
@@ -47,7 +47,8 @@ export AZ_MC_RG_NAME=$(az group list -o table | grep MC_"$AZ_RG_NAME"_ | awk '{p
 vmnodes=$(az vm list -g $AZ_MC_RG_NAME | jq -r '.[] | select (.tags.poolName | contains("node")) | .name')
 for i in $vmnodes; do
    az vm run-command invoke -g $AZ_MC_RG_NAME -n $i --command-id RunShellScript \
-   --scripts "sudo sed -i 's|linux.*./boot/vmlinuz-.*|& swapaccount=1|' /boot/grub/grub.cfg"
+     --scripts "sudo sed -i 's|linux.*./boot/vmlinuz-.*|& swapaccount=1|' /boot/grub/grub.cfg"
+   sleep 1 # avoid a weird timing issue?
 done
 
 for i in $vmnodes; do
@@ -76,7 +77,7 @@ for i in $AZ_NIC_NAMES; do
     --address-pool $AZ_AKS_NAME-lb-back
 done
 
-export CAP_PORTS="80 443 4443 2222 2793 8443"
+export CAP_PORTS="80 443 4443 2222 2793 8443 $(echo 2000{0..9})"
 
 for i in $CAP_PORTS; do
   az network lb probe create \

--- a/qa-tools/persistent-sc.yaml
+++ b/qa-tools/persistent-sc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"storage.k8s.io/v1beta1","kind":"StorageClass","metadata":{"labels":{"kubernetes.io/cluster-service":"true"},"name":"persistent","namespace":""},"parameters":{"kind":"Managed","storageaccounttype":"Standard_LRS"},"provisioner":"kubernetes.io/azure-disk"}
+  labels:
+    kubernetes.io/cluster-service: "true"
+  name: persistent
+parameters:
+  kind: Managed
+  storageaccounttype: Standard_LRS
+provisioner: kubernetes.io/azure-disk
+reclaimPolicy: Delete


### PR DESCRIPTION
Add lb rules for ports 20000-20009 in aks deploy. These allow brain tests to pass.

Also prep AKS cluster for CAP in deploy-aks script

- Create the persistent storageclass
- Install Tiller, and create cluster-admin role and binding
  (The cluster-admin role is no longer defined with newer kubes)
- Apply PodSecurityPolicy workaround
- Create cap-values configmap with IP information