### PR TITLE
Set garden rootfs driver from cap-values configmap

### DIFF
--- a/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
@@ -120,6 +120,7 @@ set_helm_params() {
     if [ -n "${KUBE_ORGANIZATION:-}" ]; then
         HELM_PARAMS+=(--set "kube.organization=${KUBE_ORGANIZATION}")
     fi
+    HELM_PARAMS+=(--set "env.GARDEN_ROOTFS_DRIVER=${garden_rootfs_driver}")
 }
 
 set_uaa_sizing_params() {
@@ -153,7 +154,8 @@ set -o allexport
 # The external_ip is set to the internal ip of a worker node. When running on openstack or azure, 
 # the public IP (used for DOMAIN) will be taken from the floating IP or load balancer IP.
 external_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["internal-ip"]')
-public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"] // empty')
+public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
+garden_rootfs_driver=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["garden-rootfs-driver"] // "btrfs"')
 
 # Domain for SCF. DNS for *.DOMAIN must point to the same kube node
 # referenced by external_ip.

--- a/qa-tools/deploy-aks.sh
+++ b/qa-tools/deploy-aks.sh
@@ -122,6 +122,6 @@ echo -e "\n Resource Group:\t$AZ_RG_NAME\n \
 Public IP:\t\t${public_ip}\n \
 Private IPs:\t\t\"$(IFS=,; echo "${internal_ips[*]}")\"\n"
 
-docker run --rm -it -v $KUBECONFIG:/root/.kube/config splatform/cf-ci-orchestration kubectl create configmap -n kube-system cap-values --from-literal=internal-ip=${internal_ips[0]} --from-literal=public-ip=$public_ip
+docker run --rm -it -v $KUBECONFIG:/root/.kube/config splatform/cf-ci-orchestration kubectl create configmap -n kube-system cap-values --from-literal=internal-ip=${internal_ips[0]} --from-literal=public-ip=$public_ip --from-literal=garden-rootfs-driver=overlay-xfs
 cat persistent-sc.yaml cap-psp-rbac.yaml cluster-admin.yaml | docker run --rm -i -v $KUBECONFIG:/root/.kube/config splatform/cf-ci-orchestration kubectl create -f -
 docker run --rm -it -v $KUBECONFIG:/root/.kube/config splatform/cf-ci-orchestration helm init


### PR DESCRIPTION
Verified that this sets the right parameter on the helm release when the `garden-rootfs-driver` key is in the `cap-values` configmap