### PR TITLE
Enable pre upgrade cats for custom scf bundles

### DIFF
--- a/qa-pipelines/flags.yml
+++ b/qa-pipelines/flags.yml
@@ -11,8 +11,15 @@ enable-cf-deploy-pre-upgrade: true
 enable-cf-smoke-tests-pre-upgrade: true
 enable-cf-brain-tests-pre-upgrade: true
 
+# This should *only* ever be true when running a *full* pre-upgrade pipeline. The only reason to do this is
+# when you want to deploy a pipeline which uses a custom config URL instead of determining it from the
+# s3.scf-config-* resources. A typical upgrade pipeline only runs cats post-upgrade, and a typical deploy
+# pipeline has all the 'pre-upgrade' flags set to false
+enable-cf-acceptance-tests-pre-upgrade: false
+
 # deploy mysql and postgres services, sidecars, and sample apps before an upgrade
 enable-usb-deploy: true
+
 
 # upgrade cf deployment to latest. When this is set to true, URLs for the pre-upgrade charts should be provide
 enable-cf-upgrade: true

--- a/qa-pipelines/qa-pipeline.yml
+++ b/qa-pipelines/qa-pipeline.yml
@@ -97,6 +97,14 @@ jobs:
       ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
     input_mapping:
       s3.scf-config: s3.scf-config-opensuse
+  - task: acceptance-tests-pre-upgrade
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      CAP_CHART: -opensuse
+      CAP_INSTALL_VERSION: ((cap-opensuse-url))
+      ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
   - task: usb-deploy
     file: ci/qa-pipelines/tasks/usb-deploy.yml
     params:
@@ -203,6 +211,14 @@ jobs:
       ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
     input_mapping:
       s3.scf-config: s3.scf-config-sles
+  - task: acceptance-tests-pre-upgrade
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      CAP_CHART: ""
+      CAP_INSTALL_VERSION: ((cap-sle-url))
+      ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
   - task: usb-deploy
     file: ci/qa-pipelines/tasks/usb-deploy.yml
     params:
@@ -313,6 +329,14 @@ jobs:
       ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
     input_mapping:
       s3.scf-config: s3.scf-config-opensuse
+  - task: acceptance-tests-pre-upgrade
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      CAP_CHART: -opensuse
+      CAP_INSTALL_VERSION: ((cap-opensuse-url))
+      ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
   - task: usb-deploy
     file: ci/qa-pipelines/tasks/usb-deploy.yml
     params:
@@ -419,6 +443,14 @@ jobs:
       ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
     input_mapping:
       s3.scf-config: s3.scf-config-sles
+  - task: acceptance-tests-pre-upgrade
+    file: ci/qa-pipelines/tasks/run-test.yml
+    params:
+      CAP_CHART: ""
+      CAP_INSTALL_VERSION: ((cap-sle-url))
+      ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
+    input_mapping:
+      s3.scf-config: s3.scf-config-opensuse
   - task: usb-deploy
     file: ci/qa-pipelines/tasks/usb-deploy.yml
     params:

--- a/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
@@ -12,6 +12,7 @@ CAP_DIRECTORY=s3.scf-config
 
 if [ -n "${CAP_INSTALL_VERSION:-}" ]; then
     # For pre-upgrade deploys
+    echo "Using CAP ${CAP_INSTALL_VERSION}"
     curl ${CAP_INSTALL_VERSION} -Lo cap-install-version.zip
     export CAP_DIRECTORY=cap-install-version
     unzip ${CAP_DIRECTORY}.zip -d ${CAP_DIRECTORY}/

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -14,7 +14,7 @@ set_helm_params # Sets HELM_PARAMS
 set_uaa_sizing_params # Adds uaa sizing params to HELM_PARAMS
 
 echo UAA customization ...
-echo "${HELM_PARAMS[@]}"
+echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
 
 # Deploy UAA
 kubectl create namespace "${UAA_NAMESPACE}"
@@ -38,7 +38,7 @@ set_helm_params # Resets HELM_PARAMS
 set_scf_sizing_params # Adds scf sizing params to HELM_PARAMS
 
 echo SCF customization ...
-echo "${HELM_PARAMS[@]}"
+echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
 
 kubectl create namespace "${CF_NAMESPACE}"
 if [[ ${PROVISIONER} == kubernetes.io/rbd ]]; then

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -13,6 +13,9 @@ source "ci/qa-pipelines/tasks/cf-deploy-upgrade-common.sh"
 set_helm_params # Sets HELM_PARAMS
 set_uaa_sizing_params # Adds uaa sizing params to HELM_PARAMS
 
+echo UAA customization ...
+echo "${HELM_PARAMS[@]}"
+
 # Deploy UAA
 kubectl create namespace "${UAA_NAMESPACE}"
 if [[ ${PROVISIONER} == kubernetes.io/rbd ]]; then
@@ -33,6 +36,9 @@ CA_CERT="$(get_internal_ca_cert)"
 
 set_helm_params # Resets HELM_PARAMS
 set_scf_sizing_params # Adds scf sizing params to HELM_PARAMS
+
+echo SCF customization ...
+echo "${HELM_PARAMS[@]}"
 
 kubectl create namespace "${CF_NAMESPACE}"
 if [[ ${PROVISIONER} == kubernetes.io/rbd ]]; then

--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -7,7 +7,8 @@ if   [[ $ENABLE_CF_SMOKE_TESTS_PRE_UPGRADE == true ]] || \
 elif [[ $ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE == true ]] || \
      [[ $ENABLE_CF_BRAIN_TESTS == true ]]; then
   TEST_NAME=acceptance-tests-brain
-elif [[ $ENABLE_CF_ACCEPTANCE_TESTS == true ]]; then
+elif [[ $ENABLE_CF_ACCEPTANCE_TESTS == true ]] || \
+     [[ $ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE == true ]]; then
   TEST_NAME=acceptance-tests
 else
   echo "run-tests.sh: No test flag set. Skipping tests"


### PR DESCRIPTION
Integrates https://github.com/SUSE/cf-ci/pull/146 for purposes of testing with AKS clusters.

This adds the acceptance tests to the list of tasks which can be run
'pre-upgrade', but this is intended for pipelines which don't actually
perform an upgrade. In this case, the 'cap-\*-url's in the config-\*.yml
file used can be changed to a custom URL where a zip of the desired
charts can be fetched from, and a preset file which only sets
'-pre-upgrade' flags to true can be used for deploying the pipeline