### PR TITLE
Use SUSE specific branches for minibroker, charts

### DIFF
--- a/minibroker/config-production.yaml
+++ b/minibroker/config-production.yaml
@@ -2,12 +2,12 @@ src-owner:                   SUSE
 src-repo:                         minibroker
 src-name:                    SUSE/minibroker
 src-repo-ref: git@github.com:SUSE/minibroker.git
-src-branch: master
+src-branch: suse-cf
 
 helm-charts-src-repo:                         charts
 helm-charts-src-name:                    SUSE/charts
 helm-charts-src-repo-ref: git@github.com:SUSE/charts.git
-helm-charts-src-branch: suse
+helm-charts-src-branch: suse-cf
 
 ci-repo: https://github.com/SUSE/cf-ci.git
 ci-branch: master


### PR DESCRIPTION
This makes it more obvious that we have SUSE specific changes to the
repos to rebase on upstream's master.