### PR TITLE
Pause jobs & unpause pipeline for new pipelines

### DIFF
--- a/qa-pipelines/set-pipeline
+++ b/qa-pipelines/set-pipeline
@@ -117,6 +117,17 @@ fi
 # Append tag/branch name to pipeline name
 pipeline_name=${pipeline_name}-${src_ci_branch}
 
+# Determine if pipeline already exists. This will be used to pause the jobs by default
+existing_pipeline_job_count=$(
+  fly ${target:+"--target=${target}"} get-pipeline --json -p "${pipeline_name}" | \
+    jq '.jobs | length'
+)
+if [[ ${existing_pipeline_job_count} -gt 0 ]]; then
+  pipeline_already_existed=true
+else
+  pipeline_already_existed=false
+fi
+
 # We concatenate our secrets file, pipeline variables, preset file (which sets
 # 'enable' flags for each task needed for this pipeline deployment), and an
 # additional set of 'false' enable flags, for every flag which is not mentioned in
@@ -125,6 +136,7 @@ pipeline_name=${pipeline_name}-${src_ci_branch}
 fly \
     ${target:+"--target=${target}"} \
     set-pipeline \
+    --non-interactive \
     --pipeline="${pipeline_name}" \
     --var pipeline-name="${pipeline_name}" \
     --config="${pipeline_file}" \
@@ -139,11 +151,19 @@ fly \
           puts YAML.dump((all_flags - pipeline_flags).zip([false].cycle).to_h)
 EOF
     )
+
 fly \
     ${target:+"--target=$target"} \
     expose-pipeline \
     --pipeline="${pipeline_name}"
-# fly \
-#     ${target:+"--target=$target"} \
-#     unpause-pipeline \
-#     --pipeline="${pipeline_name}"
+
+if ! ${pipeline_already_existed}; then
+  job_names=$(
+    fly ${target:+"--target=${target}"} get-pipeline --json -p "${pipeline_name}" | \
+      jq -r '.jobs[] | .name'
+  )
+  for job_name in ${job_names}; do
+    fly ${target:+"--target=${target}"} pause-job -j "${pipeline_name}/${job_name}"
+  done
+  fly ${target:+"--target=${target}"} unpause-pipeline --pipeline="${pipeline_name}"
+fi


### PR DESCRIPTION
When creating a new pipeline, all jobs should be paused automatically,
and the pipeline itself should be unpaused. Currently, the pipeline is
paused by default and if the jobs themselves aren't manually paused, all
jobs can automatically start when the pipeline is unpaused.

By pausing all jobs by default and unpausing the pipeline, jobs for
newly created pipelines won't start automatically, and a user can
manually unpause a job when they want to run it.

If the pipeline which is being set already existed, update the pipeline
according to the new parameters, but don't pause or unpause the pipeline
or its jobs.