### PR TITLE
2.11.0 upgrades and HA upgrades workarounds

### DIFF
--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -66,15 +66,15 @@ CA_CERT="$(get_internal_ca_cert)"
 set_helm_params # Resets HELM_PARAMS
 set_scf_sizing_params # Adds scf sizing params to HELM_PARAMS
 
-for role in blobstore diego-cell doppler nats ; do kubectl delete sts --namespace=${CF_NAMESPACE} --cascade=false $role ; done
-helm upgrade scf ${CAP_DIRECTORY}/helm/cf${CAP_CHART}/ \
+helm upgrade --force scf ${CAP_DIRECTORY}/helm/cf${CAP_CHART}/ \
     --namespace "${CF_NAMESPACE}" \
     --timeout 600 \
     --set "secrets.CLUSTER_ADMIN_PASSWORD=${CLUSTER_ADMIN_PASSWORD:-changeme}" \
     --set "env.UAA_HOST=${UAA_HOST}" \
     --set "env.UAA_PORT=${UAA_PORT}" \
     --set "secrets.UAA_CA_CERT=${CA_CERT}" \
-    "${HELM_PARAMS[@]}"
+    "${HELM_PARAMS[@]}" \
+    --recreate-pods
 
 # Wait for CF namespace
 wait_for_namespace "${CF_NAMESPACE}"


### PR DESCRIPTION
https://trello.com/c/6JJQyRlj/741-2101-211-ha-upgrades-fail
https://trello.com/c/d2wjC5bW/737-2101-to-2110-scf-upgrade-fails-statefulsetapps-blobstore-is-invalid