### PR TITLE
Temporary workaround for brains psp issue

### DIFF
--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -10,6 +10,9 @@ elif [[ $ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE == true ]] || \
 elif [[ $ENABLE_CF_ACCEPTANCE_TESTS == true ]] || \
      [[ $ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE == true ]]; then
   TEST_NAME=acceptance-tests
+  if ! kubectl get clusterrolebinding -o json cap:clusterrole | jq -e  '.subjects[] | select(.name=="test-brain")' > /dev/null; then
+    kubectl apply -f ci/qa-tools/cap-psp-rbac.yaml
+  fi
 else
   echo "run-tests.sh: No test flag set. Skipping tests"
   exit 0

--- a/qa-tools/cap-psp-rbac.yaml
+++ b/qa-tools/cap-psp-rbac.yaml
@@ -101,3 +101,9 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: mysql-sidecar
+# Workaround test-brain serviceaccount psp issue for brains tests.
+# We should remove the line which checks for this in run-test when we have a better
+# way of adding the appropriate permissions to the brain tests
+- kind: ServiceAccount
+  name: test-brain
+  namespace: scf


### PR DESCRIPTION
Right now we have a 'test-brain' service-account which the manifest for
our brains test suite is associated with. Unfortunately this
service-account wasn't referenced in the clusterrolebinding for our psp
workaround, so the pod doesn't have the right privileges for its NFS
test. This adds the 'test-brain' service-account to the psp workaround
clusterrolebinding, and when running the brains test suite in the
pipeline, will kubectl apply the workaround again if the 'test-brain'
serviceaccount isn't already included in the existing clusterrolebinding