### PR TITLE
Make ACCEPTANCE_TEST_NODES configurable

### DIFF
--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -26,6 +26,8 @@ set -o nounset
 set -o allexport
 # Set this to skip a test, e.g. 011
 EXCLUDE_BRAINS_PREFIX=011
+# Set this to define number of parallel ginkgo nodes in the acceptance test pod
+ACCEPTANCE_TEST_NODES=3
 DOMAIN=$(kubectl get pods -o json --namespace scf api-0 | jq -r '.spec.containers[0].env[] | select(.name == "DOMAIN").value')
 CF_NAMESPACE=scf
 CAP_DIRECTORY=s3.scf-config
@@ -53,6 +55,7 @@ kube_overrides() {
             container['env'].each do |env|
                 env['value'] = '$DOMAIN'     if env['name'] == 'DOMAIN'
                 env['value'] = 'tcp.$DOMAIN' if env['name'] == 'TCP_DOMAIN'
+                env['value'] = '$ACCEPTANCE_TEST_NODES' if env['name'] == 'ACCEPTANCE_TEST_NODES'
                 if env['name'] == "MONIT_PASSWORD"
                     env['valueFrom']['secretKeyRef']['name'] = '$generated_secrets_secret' 
                 end


### PR DESCRIPTION
PLEASE DO NOT MERGE BEFORE https://github.com/SUSE/scf/pull/1706 IS IN THE PRODUCT BUILD.

This change makes the number of ginko nodes in the acceptance test pod configurable for the cf-ci pipeline. I did test this with the QA pipeline using a custom acceptance test chart that had the changes from https://github.com/SUSE/scf/pull/1706.