### PR TITLE
cf-usb/config-production: Add dummy cert

### DIFF
--- a/cf-usb/config-production.yaml
+++ b/cf-usb/config-production.yaml
@@ -10,7 +10,59 @@ docker-username: *docker-internal-username
 docker-password: *docker-internal-password
 
 docker-cert-domain: unused.invalid
-docker-cert-ca: ~
+docker-cert-ca: |
+  # Generated cert, passphrase was never saved
+  -----BEGIN CERTIFICATE-----
+  MIIJETCCBPugAwIBAgIBATALBgkqhkiG9w0BAQswGTEXMBUGA1UEAxMOdW51c2Vk
+  LmludmFsaWQwIBcNMTgwOTE3MTg0NTE3WhgPMzAxODA5MTcxOTQ2NTRaMBkxFzAV
+  BgNVBAMTDnVudXNlZC5pbnZhbGlkMIIEIjANBgkqhkiG9w0BAQEFAAOCBA8AMIIE
+  CgKCBAEAwnvAYNKrEtY5c0ZsKq69jkXF+5twDsK6Y1dksK4Cn3cKlqqJprfRkSVz
+  lCd/JMO+iI6iPqa6AnvsqTb9hC5d2e2Nc1OsNJn2XOTr4WYYf7XWsxj/evvpdlGe
+  9oZw3AgYLcn51OqZckuCOgLPaEC160ijq7rRRXIyiM0CNR12ZLzuAbpx9mw+R8Dm
+  /g1pTJhAnrsDUYsejhAbYCoE2b4+5WPJ7k74gS7l5/xiZtIW9QlKGN5Z0AA7krum
+  M/SyrUCRvZavivtGasVvX4JypFkwU/HVtV6MHpz7aX67JqOxIN8ObHNT3CbzIHBr
+  hYz6Dj4bDFvsLlpG0BPMhWjQYHF4xYRcmF6R51grJSaYcSUpJOPDw7cVd0Oc3OAd
+  tW7rG+8hsG0P+FNQSsRE54wZhEz4GkMCG8xLZMUb4gGd3+fi0obvieVryb1HuLd8
+  SkfR3q4J6mK3cBAbPvcxh3Qa5c+AeyE2G3uzvXVhBdypDAG5aXi77DqHxckvSBye
+  qdSTXC1ft08d26jIGjJ8AuvKZ6o+pYDDnhYLl4+uagrSKkoar+rDm8JDvBKS1b1z
+  91/rZGVqlidDo/9HIjEWBfFuMN6/Fga6h+zU+gn03AArAnpbLijyXNL8cKGcmLRu
+  uWaDEfgb1HedpubxxokWuMIlRJL51k0G7rHJRAgU21EkLBv7wb43X2Teq+YHgu1O
+  pvjLClkZRus83IVcNbMKmwoeZEay1Ev51UMv//Lrs3F0xvTSN/WRUkv6T67NKdFd
+  YNVM4KVoGrapqbLlVMcnoksy7qsKMfs1/WM+DOaNBD7H2iOcAFAvhEeGmVmu3kR+
+  yCWUIAxuFcq/zbKosHqA0ICngQeNRn4YH2GnVhJ8cWMja5E6TKroXksPi3mOg+GA
+  Z8VMRKtZwSL+AUaE6RaKHk7bBdZLcXrxdTqdewSokGavB/cQd4+VeoHlN5PTXeM7
+  EHcaKxYBhU7h/CX5XfPcRXZ9GVrpDm38vEqOai5V8eyFUQov/1UszZDwXxCbrbtT
+  iEXjxyqZ9bAIdEB+3ct7q9aWHiLNSFozBkPEPFpj/2GsB2E0uG1qAXAmfHHUygII
+  BqmSZnN8MjFSpsQbWzlnY7LjDDVd3ZdlLvVvQ9iJQHuRhTvmpqUvLU9t7xhdlCkp
+  J2HfEAls5X9iO+zmq7QTZKWDpW4BIipUP7wsOehJnk0v1KrX2UqaVpj72tao+6wV
+  rOL7lvEhDGkHSZV7eWEBJNT5lDL6/5Q+XdpAqqm04Mal6Lk6+kyfbMYvCUoxtQys
+  z5ImdFFmLK4S45yHqPkrUCyXp42tiL6q+wQrZGdYc/wDuKATGreaWF7alqO37okk
+  qXtcg37UDuQzW7cdGhbNfZoapaFEGQIDAQABo2YwZDAOBgNVHQ8BAf8EBAMCAAYw
+  EgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQUjA5TvxwtbAsm70ieJI2BJ1Pn
+  ESIwHwYDVR0jBBgwFoAUjA5TvxwtbAsm70ieJI2BJ1PnESIwCwYJKoZIhvcNAQEL
+  A4IEAQAhTMw2QwYnhzh0j3X+bd4pDGrK6d6oSUT2gPq0VD8E9HWB4ksm9bAiUXoO
+  KBv21v6ojUfuNvkxnDD7F+4GGP8gVoGTGRRgyK4/r00M4oLaBPWzXf53ROI9wHFZ
+  SpBbfhAenv9WylSrSqKd8ioMSQ9LAMVCT9XTz2LMe364yHmQWpevZ0qpMhv+dux4
+  JCZpEc4BFJbWv6UL+fcpiICSbmW+qAe46XPqQsxgN/Sukwv4oXXYHN69ZlAAjyPK
+  1Sw/uo2qWgkX1ABRBTifv2akklqyNeHiPa97HbiGfFlTImeYYoVD6kehvs4unnid
+  6SET5dEwXZ2vp2nUqAnxBr7jVMxKQs+E+DjOu5+NAvh+1nCtaye3o27H/AyBQy4U
+  EYbu7uhH52TrzJi/uIV42WJ5EQIVDMIbSDmB9rTZv0lNqQER9kjHsI2gNwb0sbd7
+  YtwPuWxs5IGLgfrtoXhCG9RiDodpuBTpT0ZkZ7cBwj+Xhm6GXFBeSwd9chHnwuEl
+  YbGOYCS1030eJFYSwCseMQN1n1QnxMUgcc4rNPz/k+ZMB61tYAIL9n3ZMV6bIrJn
+  qotSE7Rv4FESHC6y8Lkrnn0TAngT2G4L9sDjRBuNazJ2E88SSQnejQ0fQr0vECyK
+  aMCiANn5Q3a7Iztss35+YFe2a+Pc/akMBg1n41lEuLlnYBx3/InGzbzgQCtgolx8
+  Vyz/xP7NxEETkTQLbRdDz2f9+dxJ1pj3ZM2sLcAQ7c5YREEJbIj1eGLxG6lshcO2
+  +tXg9jVhjdEnrcEJvBSZOMFcqQG+0ILtbr/8L+rpszSpjn8XXV4HqKgYQUYGr0aG
+  ntoizhPCyDUqGL1qUzEphZnRL/9ahs9M7HeJ7zgtyb9hu+hwRlwN1vLgkDlQERNf
+  T6oQpydfmuqAvttfdS35NpUzTDYRQBuqcTLHunSoewIjdr3ip5CvdtI7MqqlhlDW
+  339vaRNDTQ2sCgV6Fmrf+N5IGi6zr+4sZRORHaUOicF5Dov1nESN9cy1WNIkfjiN
+  rBiUmsYESxK1ZalzY+/IwY6Nx7UVO0UX1UMDC0Oua9CRvISJpsVB8oChDtYVZz22
+  48hRtQXbuIl2zxHOpba4NelgObhJ3TqGE0DWCYYh+oJyix7GprAEM7gsNKTH3MVe
+  ZKVIgI4akqbotxJ5aK36BhZIetKxhIhjqQW/goJ+nd0UueCB1su27sN7H/ADgMEo
+  sMWe9T5yRyntdIjz4B0nhoZFgW0ecjboW6lDnNBOmyC9pi5XwWQv5+pedSZtL+9x
+  qWhbu393WWeUwEUFfF6af4z63uJOSMn/i3t34LqcDXQDl32diZZ0q1NFOpr1L6WA
+  C457PGnpcZaGm4PkQCPEtyc1tTxQ
+  -----END CERTIFICATE-----
 
 buildbase-base-image: opensuse:latest
 buildbase-repo-cloud-tools: obs://Cloud:Tools


### PR DESCRIPTION
Concourse 4.0 doesn't like having a null CA cert anymore.  Add a dummy CA certificate that is freshly generated, but the key passphrase was never recorded.

The key was generated with (all on one line):
```bash
  certstrap init --years 1000 --cn unused.invalid --passphrase
  <(head -c256 /dev/urandom | base64 ) --stdout --key-bits 8192
```