### PR TITLE
Wait for release jobs to complete before ns pods

### DIFF
--- a/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
@@ -60,23 +60,46 @@ is_namespace_ready() {
         | sort \
         | uniq) ]]
 }
-
-wait_for_namespace() {
-    local namespace="$1"
+wait_for_jobs() {
+    local release=$1
+    local jobs_desired_remaining
     start=$(date +%s)
-    for (( i = 0  ; i < 960 ; i ++ )) ; do
+    for (( i = 0 ; i < 480 ; i ++ )); do
+        # Get the list of all jobs in the helm release, and subtract the value of 'completed' from 'desired'
+        # It would be better to parse this from `helm get manifest`, but since that command is broken in helm 
+        # v2.8.2 (https://github.com/helm/helm/issues/3833) for now we'll parse it from the human-readable status
+        jobs_desired_remaining=$(helm status $release | awk '/==> v1\/Job/ { getline; getline; while (NF>0) { print $2 - $3; getline } }')
+        now=$(date +%s)
+        if [[ $(echo "${jobs_desired_remaining}" | sort -n | tail -1) -le 0 ]]; then
+           printf "\rDone waiting for %s jobs at %s (%ss)..." "${release}" "$(date --rfc-2822)" $((${now} - ${start}))
+           return 0
+        else
+           sleep 10
+        fi
+        printf "\rWaiting for %s jobs at %s (%ss)..." "${release}" "$(date --rfc-2822)" $((${now} - ${start}))
+    done
+    printf "%s jobs not completed\n" "${release}"
+    return 1
+}
+
+wait_for_release() {
+    local release=$1
+    local namespace=$(helm list | awk '$1=="'"$release"'" {print $NF}')
+    start=$(date +%s)
+    wait_for_jobs $release || exit 1
+    for (( i = 0  ; i < 480 ; i ++ )) ; do
         if is_namespace_ready "${namespace}" ; then
             break
         fi
         now=$(date +%s)
-        printf "\rWaiting for %s at %s (%ss)..." "${namespace}" "$(date --rfc-2822)" $((${now} - ${start}))
+        printf "\rWaiting for %s pods at %s (%ss)..." "${release}" "$(date --rfc-2822)" $((${now} - ${start}))
         sleep 10
     done
     now=$(date +%s)
-    printf "\rDone waiting for %s at %s (%ss)\n" "${namespace}" "$(date --rfc-2822)" $((${now} - ${start}))
+    printf "\rDone waiting for %s pods at %s (%ss)\n" "${release}" "$(date --rfc-2822)" $((${now} - ${start}))
     kubectl get pods --namespace="${namespace}"
     if ! is_namespace_ready "${namespace}" ; then
-        printf "Namespace %s is still pending\n" "${namespace}"
+        printf "%s pods are still pending\n" "${release}"
         exit 1
     fi
 }

--- a/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
@@ -83,8 +83,8 @@ wait_for_jobs() {
 }
 
 wait_for_release() {
-    local release=$1
-    local namespace=$(helm list | awk '$1=="'"$release"'" {print $NF}')
+    local release="$1"
+    local namespace=$(helm list "${release}" | awk '$1=="'"$release"'" {print $NF}')
     start=$(date +%s)
     wait_for_jobs $release || exit 1
     for (( i = 0  ; i < 480 ; i ++ )) ; do

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -28,8 +28,8 @@ helm install ${CAP_DIRECTORY}/helm/uaa${CAP_CHART}/ \
     --timeout 600 \
     "${HELM_PARAMS[@]}"
 
-# Wait for UAA namespace
-wait_for_namespace "${UAA_NAMESPACE}"
+# Wait for UAA release
+wait_for_release uaa
 
 # Deploy CF
 CA_CERT="$(get_internal_ca_cert)"
@@ -55,5 +55,5 @@ helm install ${CAP_DIRECTORY}/helm/cf${CAP_CHART}/ \
     --set "secrets.UAA_CA_CERT=${CA_CERT}" \
     "${HELM_PARAMS[@]}"
 
-# Wait for CF namespace
-wait_for_namespace "${CF_NAMESPACE}"
+# Wait for CF release
+wait_for_release scf

--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -59,8 +59,8 @@ helm upgrade uaa ${CAP_DIRECTORY}/helm/uaa${CAP_CHART}/ \
     --timeout 600 \
     "${HELM_PARAMS[@]}"
 
-# Wait for UAA namespace
-wait_for_namespace "${UAA_NAMESPACE}"
+# Wait for UAA release
+wait_for_release uaa
 
 # Deploy CF
 CA_CERT="$(get_internal_ca_cert)"
@@ -78,8 +78,8 @@ helm upgrade scf ${CAP_DIRECTORY}/helm/cf${CAP_CHART}/ \
     --set "secrets.UAA_CA_CERT=${CA_CERT}" \
     "${HELM_PARAMS[@]}"
 
-# Wait for CF namespace
-wait_for_namespace "${CF_NAMESPACE}"
+# Wait for CF release
+wait_for_release scf
 
 echo "Post Upgrade Users and Orgs State:"
 cf api --skip-ssl-validation "https://api.${DOMAIN}"

--- a/qa-pipelines/tasks/usb-deploy.sh
+++ b/qa-pipelines/tasks/usb-deploy.sh
@@ -129,7 +129,6 @@ is_namespace_ready() {
 }
 
 wait_for_namespace() {
-  # This should be the same as wait_for_namespace in cf_deploy, other than a shorter timeout
   local namespace="$1"
   start=$(date +%s)
   for (( i = 0  ; i < 120 ; i ++ )) ; do


### PR DESCRIPTION
This adds an additional wait for job completion (determined from the helm release data) before moving on to waiting for pods to become ready.