### PR TITLE
Only print recurring failures when CATs has run 5x

### DIFF
--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -116,9 +116,9 @@ while [[ -z $(container_status ${TEST_NAME}) ]]; do
 done
 
 pod_status=$(container_status ${TEST_NAME})
+export CATS_RERUN=1
 
 if [[ ${TEST_NAME} == "acceptance-tests" ]] && [[ $pod_status -gt 0 ]]; then
-    export CATS_RERUN=1
     # Put an actual string here, because even after failing tests, if no current failures match recurring_failures, this will
     # then get set to an empty string which is considered a passing state, since intermittent failures are nearly inevitable
     # on some platforms
@@ -178,7 +178,7 @@ if [[ ${TEST_NAME} == "acceptance-tests" ]] && [[ $pod_status -gt 0 ]]; then
 fi
 
 if [[ ${TEST_NAME} == "acceptance-tests" ]]; then
-    if [[ -n ${recurring_failures} ]]; then
+    if [[ ${CATS_RERUN} -eq 5 ]] && [[ -n ${recurring_failures} ]]; then
         # This only happens if acceptance-tests fail 5 times with at least one error which appears in all runs
         echo "Failures which recurred in all runs"
         echo "${recurring_failures}"


### PR DESCRIPTION
If CATs passes on the first run, recurring_failures never gets set, and
the check for recurring_failures when printing results from CATs yields
an error due to the errexit shell option. Since recurring_failures is
empty when passing, but can also be "unset" (when re-running CATs, to
signal current_failures to be copied to recurring_failures without the
check for overlap), it has a few possible states by the time we get to
the final check. To avoid checking it when one of those states can
actually be an unset variable, we can check the value of CATS_RERUN
first, because it will always equal 5 when there are recurring failures.