### PR TITLE
Fix regex which finds CATs failures

### DIFF
--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -129,7 +129,7 @@ if [[ ${TEST_NAME} == "acceptance-tests" ]] && [[ $pod_status -gt 0 ]]; then
             kubectl logs --namespace=scf acceptance-tests \
             | perl -pe 's@\e.*?m@@g' \
             | awk '
-                /Summarizing [0-9]+ Failures/ {
+                /Summarizing [0-9]+ Failure/ {
                     numfailures=$2
                 }
                 ( numfailures > 0 ) && ( /\[Fail\]/ ) {


### PR DESCRIPTION
Right now it looks for 'failureS' but should also match '1 failure'