### PR TITLE
Add 'pre-upgrade' to HA SLES first smoke task name

### DIFF
--- a/qa-pipelines/qa-pipeline.yml
+++ b/qa-pipelines/qa-pipeline.yml
@@ -427,7 +427,7 @@ jobs:
       ENABLE_CF_DEPLOY_PRE_UPGRADE: ((enable-cf-deploy-pre-upgrade))
     input_mapping:
       s3.scf-config: s3.scf-config-sles
-  - task: cf-smoke-tests
+  - task: cf-smoke-tests-pre-upgrade
     file: ci/qa-pipelines/tasks/run-test.yml
     params:
       CAP_CHART: ""


### PR DESCRIPTION
The pre-upgrade smoke test task name for the HA SLES job didn't have
'pre-upgrade' in the name (all other pre-upgrade tasks have it)