### PR TITLE
Add GitHub status on all pipelines

### DIFF
--- a/qa-pipelines/config-azure.yml
+++ b/qa-pipelines/config-azure.yml
@@ -26,5 +26,6 @@ organization: splatform
 
 magic-dns-service: omg.howdoi.website
 
+src-repo: SUSE/scf
 cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.13.3%2Bcf2.7.0.0.gf95d9aed.zip
 cap-opensuse-url: https://s3.amazonaws.com/cap-release-archives/master/scf-opensuse-2.13.3%2Bcf2.7.0.0.gf95d9aed.zip

--- a/qa-pipelines/config-capci.yml
+++ b/qa-pipelines/config-capci.yml
@@ -28,5 +28,6 @@ organization: splatform
 
 magic-dns-service: omg.howdoi.website
 
+src-repo: SUSE/scf
 cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.13.3%2Bcf2.7.0.0.gf95d9aed.zip
 cap-opensuse-url: https://s3.amazonaws.com/cap-release-archives/master/scf-opensuse-2.13.3%2Bcf2.7.0.0.gf95d9aed.zip

--- a/qa-pipelines/config-ecp.yml
+++ b/qa-pipelines/config-ecp.yml
@@ -26,5 +26,6 @@ organization: splatform
 
 magic-dns-service: omg.howdoi.website
 
+src-repo: SUSE/scf
 cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.13.3%2Bcf2.7.0.0.gf95d9aed.zip
 cap-opensuse-url: https://s3.amazonaws.com/cap-release-archives/master/scf-opensuse-2.13.3%2Bcf2.7.0.0.gf95d9aed.zip

--- a/qa-pipelines/config-provo.yml
+++ b/qa-pipelines/config-provo.yml
@@ -26,5 +26,6 @@ organization: splatform
 
 magic-dns-service: omg.howdoi.website
 
+src-repo: SUSE/scf
 cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.13.3%2Bcf2.7.0.0.gf95d9aed.zip
 cap-opensuse-url: https://s3.amazonaws.com/cap-release-archives/master/scf-opensuse-2.13.3%2Bcf2.7.0.0.gf95d9aed.zip

--- a/qa-pipelines/qa-pipeline.yml
+++ b/qa-pipelines/qa-pipeline.yml
@@ -1,5 +1,12 @@
 # Concourse pipeline to deploy and upgrade CAP
 
+resource_types:
+- name: github-status
+  type: docker-image
+  source:
+    repository: resource/github-status
+    tag: release
+
 resources:
 - name: s3.pg-sidecar
   type: s3
@@ -54,467 +61,561 @@ resources:
     branch: ((kube-pool-branch))
     pool: ((kube-pool-pool))
 
+- name: status.src
+  type: github-status
+  source:
+    repo: ((src-repo))
+    access_token: ((github-access-token))
+
 jobs:
 - name: ((pipeline-name))-SA-openSUSE
   plan:
-  - aggregate:
-    - get: ci
-    - get: s3.pg-sidecar
-      trigger: true
-    - get: s3.mysql-sidecar
-      trigger: true
-    - get: s3.scf-config-opensuse
-      trigger: true
-    - put: pool.kube-hosts
-      params: {acquire: true}
+  - do:
+    - aggregate:
+      - get: ci
+      - get: s3.pg-sidecar
+        trigger: true
+      - get: s3.mysql-sidecar
+        trigger: true
+      - get: s3.scf-config-opensuse
+        trigger: true
+      - put: pool.kube-hosts
+        params: {acquire: true}
+    - task: cf-get-commit-id
+      file: ci/qa-pipelines/tasks/cf-get-commit-id.yml
+      input_mapping:
+        s3.archive: s3.scf-config-opensuse
+    - put: status.src
+      params: &status-params-SA-openSUSE
+        context: ((pipeline-name))-SA-openSUSE
+        description: "QA Pipeline: ((pipeline-name)) (openSUSE non-HA)"
+        path: commit-id/sha
+        state: pending
     on_failure:
       put: pool.kube-hosts
       params: {release: pool.kube-hosts}
-  - task: cf-deploy-pre-upgrade
-    file: ci/qa-pipelines/tasks/cf-deploy.yml
-    params:
-      CAP_CHART: -opensuse
-      HA: false
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      CAP_INSTALL_VERSION: ((cap-opensuse-url))
-      ENABLE_CF_DEPLOY_PRE_UPGRADE: ((enable-cf-deploy-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: cf-smoke-tests-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      CAP_INSTALL_VERSION: ((cap-opensuse-url))
-      ENABLE_CF_SMOKE_TESTS_PRE_UPGRADE: ((enable-cf-smoke-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: acceptance-tests-brain-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      CAP_INSTALL_VERSION: ((cap-opensuse-url))
-      ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: acceptance-tests-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      CAP_INSTALL_VERSION: ((cap-opensuse-url))
-      ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: usb-deploy
-    file: ci/qa-pipelines/tasks/usb-deploy.yml
-    params:
-      ENABLE_USB_DEPLOY: ((enable-usb-deploy))
-  - task: cf-upgrade
-    file: ci/qa-pipelines/tasks/cf-upgrade.yml
-    params:
-      CAP_CHART: -opensuse
-      HA: false
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      ENABLE_CF_UPGRADE: ((enable-cf-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: usb-post-upgrade
-    file: ci/qa-pipelines/tasks/usb-post-upgrade.yml
-    params:
-      ENABLE_USB_POST_UPGRADE: ((enable-usb-post-upgrade))
-  - task: cf-deploy
-    file: ci/qa-pipelines/tasks/cf-deploy.yml
-    params:
-      CAP_CHART: -opensuse
-      HA: false
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      ENABLE_CF_DEPLOY: ((enable-cf-deploy))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: cf-smoke-tests
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      ENABLE_CF_SMOKE_TESTS: ((enable-cf-smoke-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: acceptance-tests-brain
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      ENABLE_CF_BRAIN_TESTS: ((enable-cf-brain-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: acceptance-tests
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      ENABLE_CF_ACCEPTANCE_TESTS: ((enable-cf-acceptance-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  # We intentionally don't put the teardown and pool release steps in an ensure
-  # block, so that when tests fail we have a chance of examining why things are
-  # failing.
-  - task: cf-teardown
-    file: ci/qa-pipelines/tasks/cf-teardown.yml
-    timeout: 1h
-    params:
-      ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
-  - put: pool.kube-hosts
-    params: {release: pool.kube-hosts}
+  - do:
+    - task: cf-deploy-pre-upgrade
+      file: ci/qa-pipelines/tasks/cf-deploy.yml
+      params:
+        CAP_CHART: -opensuse
+        HA: false
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        CAP_INSTALL_VERSION: ((cap-opensuse-url))
+        ENABLE_CF_DEPLOY_PRE_UPGRADE: ((enable-cf-deploy-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: cf-smoke-tests-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        CAP_INSTALL_VERSION: ((cap-opensuse-url))
+        ENABLE_CF_SMOKE_TESTS_PRE_UPGRADE: ((enable-cf-smoke-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: acceptance-tests-brain-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        CAP_INSTALL_VERSION: ((cap-opensuse-url))
+        ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: acceptance-tests-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        CAP_INSTALL_VERSION: ((cap-opensuse-url))
+        ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: usb-deploy
+      file: ci/qa-pipelines/tasks/usb-deploy.yml
+      params:
+        ENABLE_USB_DEPLOY: ((enable-usb-deploy))
+    - task: cf-upgrade
+      file: ci/qa-pipelines/tasks/cf-upgrade.yml
+      params:
+        CAP_CHART: -opensuse
+        HA: false
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        ENABLE_CF_UPGRADE: ((enable-cf-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: usb-post-upgrade
+      file: ci/qa-pipelines/tasks/usb-post-upgrade.yml
+      params:
+        ENABLE_USB_POST_UPGRADE: ((enable-usb-post-upgrade))
+    - task: cf-deploy
+      file: ci/qa-pipelines/tasks/cf-deploy.yml
+      params:
+        CAP_CHART: -opensuse
+        HA: false
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        ENABLE_CF_DEPLOY: ((enable-cf-deploy))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: cf-smoke-tests
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        ENABLE_CF_SMOKE_TESTS: ((enable-cf-smoke-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: acceptance-tests-brain
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        ENABLE_CF_BRAIN_TESTS: ((enable-cf-brain-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: acceptance-tests
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        ENABLE_CF_ACCEPTANCE_TESTS: ((enable-cf-acceptance-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    # We intentionally don't put the teardown and pool release steps in an ensure
+    # block, so that when tests fail we have a chance of examining why things are
+    # failing.
+    - task: cf-teardown
+      file: ci/qa-pipelines/tasks/cf-teardown.yml
+      timeout: 1h
+      params:
+        ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
+    - put: pool.kube-hosts
+      params: {release: pool.kube-hosts}
+    on_success:
+      put: status.src
+      params:
+        <<: *status-params-SA-openSUSE
+        state: success
+    on_failure:
+      put: status.src
+      params:
+        <<: *status-params-SA-openSUSE
+        state: failure
 
 - name: ((pipeline-name))-SA-SLES
   plan:
-  - aggregate:
-    - get: ci
-    - get: s3.pg-sidecar
-      trigger: true
-    - get: s3.mysql-sidecar
-      trigger: true
-    - get: s3.scf-config-sles
-      trigger: true
-    - put: pool.kube-hosts
-      params: {acquire: true}
+  - do:
+    - aggregate:
+      - get: ci
+      - get: s3.pg-sidecar
+        trigger: true
+      - get: s3.mysql-sidecar
+        trigger: true
+      - get: s3.scf-config-sles
+        trigger: true
+      - put: pool.kube-hosts
+        params: {acquire: true}
+    - task: cf-get-commit-id
+      file: ci/qa-pipelines/tasks/cf-get-commit-id.yml
+      input_mapping:
+        s3.archive: s3.scf-config-sles
+    - put: status.src
+      params: &status-params-SA-SLES
+        context: ((pipeline-name))-SA-SLES
+        description: "QA Pipeline: ((pipeline-name)) (SLES non-HA)"
+        path: commit-id/sha
+        state: pending
     on_failure:
       put: pool.kube-hosts
       params: {release: pool.kube-hosts}
-  - task: cf-deploy-pre-upgrade
-    file: ci/qa-pipelines/tasks/cf-deploy.yml
-    params:
-      KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
-      KUBE_REGISTRY_USERNAME: ((registry-username))
-      KUBE_REGISTRY_PASSWORD: ((registry-password))
-      KUBE_ORGANIZATION: ((organization))
-      CAP_CHART: ""
-      HA: false
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      CAP_INSTALL_VERSION: ((cap-sle-url))
-      ENABLE_CF_DEPLOY_PRE_UPGRADE: ((enable-cf-deploy-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: cf-smoke-tests-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      CAP_INSTALL_VERSION: ((cap-sle-url))
-      ENABLE_CF_SMOKE_TESTS_PRE_UPGRADE: ((enable-cf-smoke-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: acceptance-tests-brain-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      CAP_INSTALL_VERSION: ((cap-sle-url))
-      ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: acceptance-tests-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      CAP_INSTALL_VERSION: ((cap-sle-url))
-      ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: usb-deploy
-    file: ci/qa-pipelines/tasks/usb-deploy.yml
-    params:
-      ENABLE_USB_DEPLOY: ((enable-usb-deploy))
-  - task: cf-upgrade
-    file: ci/qa-pipelines/tasks/cf-upgrade.yml
-    params:
-      KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
-      KUBE_REGISTRY_USERNAME: ((registry-username))
-      KUBE_REGISTRY_PASSWORD: ((registry-password))
-      KUBE_ORGANIZATION: ((organization))
-      CAP_CHART: ""
-      HA: false
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      ENABLE_CF_UPGRADE: ((enable-cf-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: usb-post-upgrade
-    file: ci/qa-pipelines/tasks/usb-post-upgrade.yml
-    params:
-      ENABLE_USB_POST_UPGRADE: ((enable-usb-post-upgrade))
-  - task: cf-deploy
-    file: ci/qa-pipelines/tasks/cf-deploy.yml
-    params:
-      KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
-      KUBE_REGISTRY_USERNAME: ((registry-username))
-      KUBE_REGISTRY_PASSWORD: ((registry-password))
-      KUBE_ORGANIZATION: ((organization))
-      CAP_CHART: ""
-      HA: false
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      ENABLE_CF_DEPLOY: ((enable-cf-deploy))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: cf-smoke-tests
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      ENABLE_CF_SMOKE_TESTS: ((enable-cf-smoke-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: acceptance-tests-brain
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      ENABLE_CF_BRAIN_TESTS: ((enable-cf-brain-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: acceptance-tests
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      ENABLE_CF_ACCEPTANCE_TESTS: ((enable-cf-acceptance-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  # We intentionally don't put the teardown and pool release steps in an ensure
-  # block, so that when tests fail we have a chance of examining why things are
-  # failing.
-  - task: cf-teardown
-    file: ci/qa-pipelines/tasks/cf-teardown.yml
-    timeout: 1h
-    params:
-      ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
-  - put: pool.kube-hosts
-    params: {release: pool.kube-hosts}
+  - do:
+    - task: cf-deploy-pre-upgrade
+      file: ci/qa-pipelines/tasks/cf-deploy.yml
+      params:
+        KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
+        KUBE_REGISTRY_USERNAME: ((registry-username))
+        KUBE_REGISTRY_PASSWORD: ((registry-password))
+        KUBE_ORGANIZATION: ((organization))
+        CAP_CHART: ""
+        HA: false
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        CAP_INSTALL_VERSION: ((cap-sle-url))
+        ENABLE_CF_DEPLOY_PRE_UPGRADE: ((enable-cf-deploy-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: cf-smoke-tests-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        CAP_INSTALL_VERSION: ((cap-sle-url))
+        ENABLE_CF_SMOKE_TESTS_PRE_UPGRADE: ((enable-cf-smoke-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: acceptance-tests-brain-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        CAP_INSTALL_VERSION: ((cap-sle-url))
+        ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: acceptance-tests-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        CAP_INSTALL_VERSION: ((cap-sle-url))
+        ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: usb-deploy
+      file: ci/qa-pipelines/tasks/usb-deploy.yml
+      params:
+        ENABLE_USB_DEPLOY: ((enable-usb-deploy))
+    - task: cf-upgrade
+      file: ci/qa-pipelines/tasks/cf-upgrade.yml
+      params:
+        KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
+        KUBE_REGISTRY_USERNAME: ((registry-username))
+        KUBE_REGISTRY_PASSWORD: ((registry-password))
+        KUBE_ORGANIZATION: ((organization))
+        CAP_CHART: ""
+        HA: false
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        ENABLE_CF_UPGRADE: ((enable-cf-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: usb-post-upgrade
+      file: ci/qa-pipelines/tasks/usb-post-upgrade.yml
+      params:
+        ENABLE_USB_POST_UPGRADE: ((enable-usb-post-upgrade))
+    - task: cf-deploy
+      file: ci/qa-pipelines/tasks/cf-deploy.yml
+      params:
+        KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
+        KUBE_REGISTRY_USERNAME: ((registry-username))
+        KUBE_REGISTRY_PASSWORD: ((registry-password))
+        KUBE_ORGANIZATION: ((organization))
+        CAP_CHART: ""
+        HA: false
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        ENABLE_CF_DEPLOY: ((enable-cf-deploy))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: cf-smoke-tests
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        ENABLE_CF_SMOKE_TESTS: ((enable-cf-smoke-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: acceptance-tests-brain
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        ENABLE_CF_BRAIN_TESTS: ((enable-cf-brain-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: acceptance-tests
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        ENABLE_CF_ACCEPTANCE_TESTS: ((enable-cf-acceptance-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    # We intentionally don't put the teardown and pool release steps in an ensure
+    # block, so that when tests fail we have a chance of examining why things are
+    # failing.
+    - task: cf-teardown
+      file: ci/qa-pipelines/tasks/cf-teardown.yml
+      timeout: 1h
+      params:
+        ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
+    - put: pool.kube-hosts
+      params: {release: pool.kube-hosts}
+    on_success:
+      put: status.src
+      params:
+        <<: *status-params-SA-SLES
+        state: success
+    on_failure:
+      put: status.src
+      params:
+        <<: *status-params-SA-SLES
+        state: failure
 
 - name: ((pipeline-name))-HA-openSUSE
   plan:
-  - aggregate:
-    - get: ci
-    - get: s3.pg-sidecar
-      trigger: true
-    - get: s3.mysql-sidecar
-      trigger: true
-    - get: s3.scf-config-opensuse
-      trigger: true
-    - put: pool.kube-hosts
-      params: {acquire: true}
+  - do:
+    - aggregate:
+      - get: ci
+      - get: s3.pg-sidecar
+        trigger: true
+      - get: s3.mysql-sidecar
+        trigger: true
+      - get: s3.scf-config-opensuse
+        trigger: true
+      - put: pool.kube-hosts
+        params: {acquire: true}
+    - task: cf-get-commit-id
+      file: ci/qa-pipelines/tasks/cf-get-commit-id.yml
+      input_mapping:
+        s3.archive: s3.scf-config-opensuse
+    - put: status.src
+      params: &status-params-HA-openSUSE
+        context: ((pipeline-name))-HA-openSUSE
+        description: "QA Pipeline: ((pipeline-name)) (openSUSE HA)"
+        path: commit-id/sha
+        state: pending
     on_failure:
       put: pool.kube-hosts
       params: {release: pool.kube-hosts}
-  - task: cf-deploy-pre-upgrade
-    file: ci/qa-pipelines/tasks/cf-deploy.yml
-    params:
-      CAP_CHART: -opensuse
-      HA: true
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      CAP_INSTALL_VERSION: ((cap-opensuse-url))
-      ENABLE_CF_DEPLOY_PRE_UPGRADE: ((enable-cf-deploy-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: cf-smoke-tests-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      CAP_INSTALL_VERSION: ((cap-opensuse-url))
-      ENABLE_CF_SMOKE_TESTS_PRE_UPGRADE: ((enable-cf-smoke-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: acceptance-tests-brain-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      CAP_INSTALL_VERSION: ((cap-opensuse-url))
-      ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: acceptance-tests-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      CAP_INSTALL_VERSION: ((cap-opensuse-url))
-      ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: usb-deploy
-    file: ci/qa-pipelines/tasks/usb-deploy.yml
-    params:
-      ENABLE_USB_DEPLOY: ((enable-usb-deploy))
-  - task: cf-upgrade
-    file: ci/qa-pipelines/tasks/cf-upgrade.yml
-    params:
-      CAP_CHART: -opensuse
-      HA: true
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      ENABLE_CF_UPGRADE: ((enable-cf-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: usb-post-upgrade
-    file: ci/qa-pipelines/tasks/usb-post-upgrade.yml
-    params:
-      ENABLE_USB_POST_UPGRADE: ((enable-usb-post-upgrade))
-  - task: cf-deploy
-    file: ci/qa-pipelines/tasks/cf-deploy.yml
-    params:
-      CAP_CHART: -opensuse
-      HA: true
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      ENABLE_CF_DEPLOY: ((enable-cf-deploy))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: cf-smoke-tests
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      ENABLE_CF_SMOKE_TESTS: ((enable-cf-smoke-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: acceptance-tests-brain
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      ENABLE_CF_BRAIN_TESTS: ((enable-cf-brain-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  - task: acceptance-tests
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: -opensuse
-      ENABLE_CF_ACCEPTANCE_TESTS: ((enable-cf-acceptance-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-opensuse
-  # We intentionally don't put the teardown and pool release steps in an ensure
-  # block, so that when tests fail we have a chance of examining why things are
-  # failing.
-  - task: cf-teardown
-    file: ci/qa-pipelines/tasks/cf-teardown.yml
-    timeout: 1h
-    params:
-      ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
-  - put: pool.kube-hosts
-    params: {release: pool.kube-hosts}
+  - do:
+    - task: cf-deploy-pre-upgrade
+      file: ci/qa-pipelines/tasks/cf-deploy.yml
+      params:
+        CAP_CHART: -opensuse
+        HA: true
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        CAP_INSTALL_VERSION: ((cap-opensuse-url))
+        ENABLE_CF_DEPLOY_PRE_UPGRADE: ((enable-cf-deploy-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: cf-smoke-tests-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        CAP_INSTALL_VERSION: ((cap-opensuse-url))
+        ENABLE_CF_SMOKE_TESTS_PRE_UPGRADE: ((enable-cf-smoke-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: acceptance-tests-brain-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        CAP_INSTALL_VERSION: ((cap-opensuse-url))
+        ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: acceptance-tests-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        CAP_INSTALL_VERSION: ((cap-opensuse-url))
+        ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: usb-deploy
+      file: ci/qa-pipelines/tasks/usb-deploy.yml
+      params:
+        ENABLE_USB_DEPLOY: ((enable-usb-deploy))
+    - task: cf-upgrade
+      file: ci/qa-pipelines/tasks/cf-upgrade.yml
+      params:
+        CAP_CHART: -opensuse
+        HA: true
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        ENABLE_CF_UPGRADE: ((enable-cf-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: usb-post-upgrade
+      file: ci/qa-pipelines/tasks/usb-post-upgrade.yml
+      params:
+        ENABLE_USB_POST_UPGRADE: ((enable-usb-post-upgrade))
+    - task: cf-deploy
+      file: ci/qa-pipelines/tasks/cf-deploy.yml
+      params:
+        CAP_CHART: -opensuse
+        HA: true
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        ENABLE_CF_DEPLOY: ((enable-cf-deploy))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: cf-smoke-tests
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        ENABLE_CF_SMOKE_TESTS: ((enable-cf-smoke-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: acceptance-tests-brain
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        ENABLE_CF_BRAIN_TESTS: ((enable-cf-brain-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    - task: acceptance-tests
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: -opensuse
+        ENABLE_CF_ACCEPTANCE_TESTS: ((enable-cf-acceptance-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-opensuse
+    # We intentionally don't put the teardown and pool release steps in an ensure
+    # block, so that when tests fail we have a chance of examining why things are
+    # failing.
+    - task: cf-teardown
+      file: ci/qa-pipelines/tasks/cf-teardown.yml
+      timeout: 1h
+      params:
+        ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
+    - put: pool.kube-hosts
+      params: {release: pool.kube-hosts}
+    on_success:
+      put: status.src
+      params:
+        <<: *status-params-HA-openSUSE
+        state: success
+    on_failure:
+      put: status.src
+      params:
+        <<: *status-params-HA-openSUSE
+        state: failure
 
 - name: ((pipeline-name))-HA-SLES
   plan:
-  - aggregate:
-    - get: ci
-    - get: s3.pg-sidecar
-      trigger: true
-    - get: s3.mysql-sidecar
-      trigger: true
-    - get: s3.scf-config-sles
-      trigger: true
-    - put: pool.kube-hosts
-      params: {acquire: true}
+  - do:
+    - aggregate:
+      - get: ci
+      - get: s3.pg-sidecar
+        trigger: true
+      - get: s3.mysql-sidecar
+        trigger: true
+      - get: s3.scf-config-sles
+        trigger: true
+      - put: pool.kube-hosts
+        params: {acquire: true}
+    - task: cf-get-commit-id
+      file: ci/qa-pipelines/tasks/cf-get-commit-id.yml
+      input_mapping:
+        s3.archive: s3.scf-config-sles
+    - put: status.src
+      params: &status-params-HA-SLES
+        context: ((pipeline-name))-HA-SLES
+        description: "QA Pipeline: ((pipeline-name)) (SLES HA)"
+        path: commit-id/sha
+        state: pending
     on_failure:
       put: pool.kube-hosts
       params: {release: pool.kube-hosts}
-  - task: cf-deploy-pre-upgrade
-    file: ci/qa-pipelines/tasks/cf-deploy.yml
-    params:
-      KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
-      KUBE_REGISTRY_USERNAME: ((registry-username))
-      KUBE_REGISTRY_PASSWORD: ((registry-password))
-      KUBE_ORGANIZATION: ((organization))
-      CAP_CHART: ""
-      HA: true
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      CAP_INSTALL_VERSION: ((cap-sle-url))
-      ENABLE_CF_DEPLOY_PRE_UPGRADE: ((enable-cf-deploy-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: cf-smoke-tests-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      CAP_INSTALL_VERSION: ((cap-sle-url))
-      ENABLE_CF_SMOKE_TESTS_PRE_UPGRADE: ((enable-cf-smoke-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: acceptance-tests-brain-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      CAP_INSTALL_VERSION: ((cap-sle-url))
-      ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: acceptance-tests-pre-upgrade
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      CAP_INSTALL_VERSION: ((cap-sle-url))
-      ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: usb-deploy
-    file: ci/qa-pipelines/tasks/usb-deploy.yml
-    params:
-      ENABLE_USB_DEPLOY: ((enable-usb-deploy))
-  - task: cf-upgrade
-    file: ci/qa-pipelines/tasks/cf-upgrade.yml
-    params:
-      KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
-      KUBE_REGISTRY_USERNAME: ((registry-username))
-      KUBE_REGISTRY_PASSWORD: ((registry-password))
-      KUBE_ORGANIZATION: ((organization))
-      CAP_CHART: ""
-      HA: true
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      ENABLE_CF_UPGRADE: ((enable-cf-upgrade))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: usb-post-upgrade
-    file: ci/qa-pipelines/tasks/usb-post-upgrade.yml
-    params:
-      ENABLE_USB_POST_UPGRADE: ((enable-usb-post-upgrade))
-  - task: cf-deploy
-    file: ci/qa-pipelines/tasks/cf-deploy.yml
-    params:
-      KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
-      KUBE_REGISTRY_USERNAME: ((registry-username))
-      KUBE_REGISTRY_PASSWORD: ((registry-password))
-      KUBE_ORGANIZATION: ((organization))
-      CAP_CHART: ""
-      HA: true
-      SCALED_HA: false
-      MAGIC_DNS_SERVICE: ((magic-dns-service))
-      ENABLE_CF_DEPLOY: ((enable-cf-deploy))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: cf-smoke-tests
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      ENABLE_CF_SMOKE_TESTS: ((enable-cf-smoke-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: acceptance-tests-brain
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      ENABLE_CF_BRAIN_TESTS: ((enable-cf-brain-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  - task: acceptance-tests
-    file: ci/qa-pipelines/tasks/run-test.yml
-    params:
-      CAP_CHART: ""
-      ENABLE_CF_ACCEPTANCE_TESTS: ((enable-cf-acceptance-tests))
-    input_mapping:
-      s3.scf-config: s3.scf-config-sles
-  # We intentionally don't put the teardown and pool release steps in an ensure
-  # block, so that when tests fail we have a chance of examining why things are
-  # failing.
-  - task: cf-teardown
-    file: ci/qa-pipelines/tasks/cf-teardown.yml
-    timeout: 1h
-    params:
-      ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
-  - put: pool.kube-hosts
-    params: {release: pool.kube-hosts}
+  - do:
+    - task: cf-deploy-pre-upgrade
+      file: ci/qa-pipelines/tasks/cf-deploy.yml
+      params:
+        KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
+        KUBE_REGISTRY_USERNAME: ((registry-username))
+        KUBE_REGISTRY_PASSWORD: ((registry-password))
+        KUBE_ORGANIZATION: ((organization))
+        CAP_CHART: ""
+        HA: true
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        CAP_INSTALL_VERSION: ((cap-sle-url))
+        ENABLE_CF_DEPLOY_PRE_UPGRADE: ((enable-cf-deploy-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: cf-smoke-tests-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        CAP_INSTALL_VERSION: ((cap-sle-url))
+        ENABLE_CF_SMOKE_TESTS_PRE_UPGRADE: ((enable-cf-smoke-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: acceptance-tests-brain-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        CAP_INSTALL_VERSION: ((cap-sle-url))
+        ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE: ((enable-cf-brain-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: acceptance-tests-pre-upgrade
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        CAP_INSTALL_VERSION: ((cap-sle-url))
+        ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE: ((enable-cf-acceptance-tests-pre-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: usb-deploy
+      file: ci/qa-pipelines/tasks/usb-deploy.yml
+      params:
+        ENABLE_USB_DEPLOY: ((enable-usb-deploy))
+    - task: cf-upgrade
+      file: ci/qa-pipelines/tasks/cf-upgrade.yml
+      params:
+        KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
+        KUBE_REGISTRY_USERNAME: ((registry-username))
+        KUBE_REGISTRY_PASSWORD: ((registry-password))
+        KUBE_ORGANIZATION: ((organization))
+        CAP_CHART: ""
+        HA: true
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        ENABLE_CF_UPGRADE: ((enable-cf-upgrade))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: usb-post-upgrade
+      file: ci/qa-pipelines/tasks/usb-post-upgrade.yml
+      params:
+        ENABLE_USB_POST_UPGRADE: ((enable-usb-post-upgrade))
+    - task: cf-deploy
+      file: ci/qa-pipelines/tasks/cf-deploy.yml
+      params:
+        KUBE_REGISTRY_HOSTNAME: ((registry-hostname))
+        KUBE_REGISTRY_USERNAME: ((registry-username))
+        KUBE_REGISTRY_PASSWORD: ((registry-password))
+        KUBE_ORGANIZATION: ((organization))
+        CAP_CHART: ""
+        HA: true
+        SCALED_HA: false
+        MAGIC_DNS_SERVICE: ((magic-dns-service))
+        ENABLE_CF_DEPLOY: ((enable-cf-deploy))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: cf-smoke-tests
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        ENABLE_CF_SMOKE_TESTS: ((enable-cf-smoke-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: acceptance-tests-brain
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        ENABLE_CF_BRAIN_TESTS: ((enable-cf-brain-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    - task: acceptance-tests
+      file: ci/qa-pipelines/tasks/run-test.yml
+      params:
+        CAP_CHART: ""
+        ENABLE_CF_ACCEPTANCE_TESTS: ((enable-cf-acceptance-tests))
+      input_mapping:
+        s3.scf-config: s3.scf-config-sles
+    # We intentionally don't put the teardown and pool release steps in an ensure
+    # block, so that when tests fail we have a chance of examining why things are
+    # failing.
+    - task: cf-teardown
+      file: ci/qa-pipelines/tasks/cf-teardown.yml
+      timeout: 1h
+      params:
+        ENABLE_CF_TEARDOWN: ((enable-cf-teardown))
+    - put: pool.kube-hosts
+      params: {release: pool.kube-hosts}
+    on_success:
+      put: status.src
+      params:
+        <<: *status-params-HA-SLES
+        state: success
+    on_failure:
+      put: status.src
+      params:
+        <<: *status-params-HA-SLES
+        state: failure

--- a/qa-pipelines/set-pipeline
+++ b/qa-pipelines/set-pipeline
@@ -115,7 +115,7 @@ if ! git ls-remote --exit-code $src_ci_remote $src_ci_branch; then
 fi
 
 # Append tag/branch name to pipeline name
-pipeline_name=${pipeline_name}-${src_ci_branch}
+pipeline_name=${pipeline_name}-${src_ci_branch//\//-}
 
 # Determine if pipeline already exists. This will be used to pause the jobs by default
 existing_pipeline_job_count=$(

--- a/qa-pipelines/tasks/cf-get-commit-id.sh
+++ b/qa-pipelines/tasks/cf-get-commit-id.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# inputs:
+#   s3.archive: the archive to examine
+# outputs:
+#   commit-id/sha: commit id to use (may be shortened)
+
+cat s3.archive/version \
+    | awk -F. '{print $NF}' \
+    | tr -d g \
+    | tee /dev/stderr \
+    > commit-id/sha

--- a/qa-pipelines/tasks/cf-get-commit-id.yml
+++ b/qa-pipelines/tasks/cf-get-commit-id.yml
@@ -1,0 +1,14 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: splatform/cf-ci-orchestration
+
+inputs:
+- name: ci
+- name: s3.archive
+outputs:
+- name: commit-id
+run:
+  path: ci/qa-pipelines/tasks/cf-get-commit-id.sh


### PR DESCRIPTION
This will add a GitHub status marker on the commit associated with the SCF input archive.  The name of the status context is derived from the pipeline name.

