### PR TITLE
Clear legacy PSPs/CRs/CRBs and create new ones

### DIFF
--- a/automation-scripts/prep-new-cluster.sh
+++ b/automation-scripts/prep-new-cluster.sh
@@ -58,9 +58,6 @@ if ! kubectl get storageclass persistent &> /dev/null; then
   kubectl create -f "$(dirname $0)/nfs-provisioner"
 fi
 
-echo "Enable PodSecurityPolicy"
-kubectl create -f "$(dirname $0)/../qa-tools/cap-psp-rbac.yaml"
-
 echo "Ensure the following config contents are in the lockfile for your concourse pool kube resource:"
 echo "---"
 curl -sL "https://raw.githubusercontent.com/SUSE/cf-ci/master/qa-tools/create-qa-config.sh" | bash 2>/dev/null | awk '/apiVersion/ { yaml=1 }  yaml { print }'

--- a/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
@@ -128,8 +128,8 @@ get_internal_ca_cert() (
 )
 
 set_psp() {
-    HELM_PARAMS+=(--set "kube.psp.nonprivileged=suse.cap.psp")
-    HELM_PARAMS+=(--set "kube.psp.privileged=suse.cap.psp")
+    HELM_PARAMS+=(--set "kube.psp.nonprivileged=suse.cap.psp.nonprivileged")
+    HELM_PARAMS+=(--set "kube.psp.privileged=suse.cap.psp.privileged")
 }
 
 set_helm_params() {

--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -11,9 +11,7 @@ if   [[ $ENABLE_CF_SMOKE_TESTS_PRE_UPGRADE == true ]] || \
 elif [[ $ENABLE_CF_BRAIN_TESTS_PRE_UPGRADE == true ]] || \
      [[ $ENABLE_CF_BRAIN_TESTS == true ]]; then
     TEST_NAME=acceptance-tests-brain
-    if ! kubectl get clusterrolebinding -o json cap:clusterrole | jq -e  '.subjects[] | select(.name=="test-brain")' > /dev/null; then
-        kubectl apply -f ci/qa-tools/cap-psp-rbac.yaml
-    fi
+    kubectl apply -f ci/qa-tools/cap-crb-tests.yaml
 elif [[ $ENABLE_CF_ACCEPTANCE_TESTS == true ]] || \
      [[ $ENABLE_CF_ACCEPTANCE_TESTS_PRE_UPGRADE == true ]]; then
     TEST_NAME=acceptance-tests

--- a/qa-tools/cap-cr-privileged.yaml
+++ b/qa-tools/cap-cr-privileged.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: suse:cap:psp:privileged
+rules:
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['suse.cap.psp.privileged']
+

--- a/qa-tools/cap-crb-2.13.3.yaml
+++ b/qa-tools/cap-crb-2.13.3.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cap:clusterrolebinding:2.13.3
+roleRef:
+  kind: ClusterRole
+  name: suse:cap:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: uaa
+- kind: ServiceAccount
+  name: default
+  namespace: scf

--- a/qa-tools/cap-crb-tests.yaml
+++ b/qa-tools/cap-crb-tests.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cap:clusterrolebinding:tests
+roleRef:
+  kind: ClusterRole
+  name: suse:cap:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: stratos
+- kind: ServiceAccount
+  name: default
+  namespace: pg-sidecar
+- kind: ServiceAccount
+  name: default
+  namespace: mysql-sidecar
+- kind: ServiceAccount
+  name: test-brain
+  namespace: scf

--- a/qa-tools/cap-psp-nonprivileged.yaml
+++ b/qa-tools/cap-psp-nonprivileged.yaml
@@ -2,13 +2,11 @@
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: suse.cap.psp
+  name: suse.cap.psp.nonprivileged
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
-  # Privileged
-  #privileged: false      	<<< default in suse.caasp.psp.unprivileged
-  privileged: true
+  privileged: false
   # Volumes and File Systems
   volumes:
     # Kubernetes Pseudo Volume Types
@@ -47,10 +45,8 @@ spec:
     rule: RunAsAny
   fsGroup:
     rule: RunAsAny
-  # Privilege Escalation
-  #allowPrivilegeEscalation: false	   <<< default in suse.caasp.psp.unprivileged
-  allowPrivilegeEscalation: true
-  #defaultAllowPrivilegeEscalation: false  <<< default in suse.caasp.psp.unprivileged
+  allowPrivilegeEscalation: false
+  defaultAllowPrivilegeEscalation: false
   # Capabilities
   allowedCapabilities: []
   defaultAddCapabilities: []
@@ -66,44 +62,3 @@ spec:
   seLinux:
     # SELinux is unsed in CaaSP
     rule: 'RunAsAny'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: suse:cap:psp
-rules:
-  - apiGroups: ['extensions']
-    resources: ['podsecuritypolicies']
-    verbs: ['use']
-    resourceNames: ['suse.cap.psp']
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cap:clusterrole
-roleRef:
-  kind: ClusterRole
-  name: suse:cap:psp
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: uaa
-- kind: ServiceAccount
-  name: default
-  namespace: scf
-- kind: ServiceAccount
-  name: default
-  namespace: stratos
-- kind: ServiceAccount
-  name: default
-  namespace: pg-sidecar
-- kind: ServiceAccount
-  name: default
-  namespace: mysql-sidecar
-# Workaround test-brain serviceaccount psp issue for brains tests.
-# We should remove the line which checks for this in run-test when we have a better
-# way of adding the appropriate permissions to the brain tests
-- kind: ServiceAccount
-  name: test-brain
-  namespace: scf

--- a/qa-tools/cap-psp-privileged.yaml
+++ b/qa-tools/cap-psp-privileged.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: suse.cap.psp.privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  # Volumes and File Systems
+  volumes:
+    # Kubernetes Pseudo Volume Types
+    - configMap
+    - secret
+    - emptyDir
+    - downwardAPI
+    - projected
+    - persistentVolumeClaim
+    # Networked Storage
+    - nfs
+    - rbd
+    - cephFS
+    - glusterfs
+    - fc
+    - iscsi
+    # Cloud Volumes
+    - cinder
+    - gcePersistentDisk
+    - awsElasticBlockStore
+    - azureDisk
+    - azureFile
+    - vsphereVolume
+  allowedFlexVolumes: []
+  allowedHostPaths:
+    # Note: We don't allow hostPath volumes above, but set this to a path we
+    # control anyway as a belt+braces protection. /dev/null may be a better
+    # option, but the implications of pointing this towards a device are
+    # unclear.
+    - pathPrefix: /opt/kubernetes-hostpath-volumes
+  readOnlyRootFilesystem: false
+  # Users and groups
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  # Privilege Escalation
+  #allowPrivilegeEscalation: false	   <<< default in suse.caasp.psp.unprivileged
+  allowPrivilegeEscalation: true
+  #defaultAllowPrivilegeEscalation: false  <<< default in suse.caasp.psp.unprivileged
+  # Capabilities
+  allowedCapabilities: []
+  defaultAddCapabilities: []
+  requiredDropCapabilities: []
+  # Host namespaces
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  hostPorts:
+  - min: 0
+    max: 65535
+  # SELinux
+  seLinux:
+    # SELinux is unsed in CaaSP
+    rule: 'RunAsAny'

--- a/qa-tools/deploy-aks.sh
+++ b/qa-tools/deploy-aks.sh
@@ -124,5 +124,5 @@ Public IP:\t\t${public_ip}\n \
 Private IPs:\t\t\"$(IFS=,; echo "${internal_ips[*]}")\"\n"
 
 docker run --rm -it -v $KUBECONFIG:/root/.kube/config splatform/cf-ci-orchestration kubectl create configmap -n kube-system cap-values --from-literal=internal-ip=${internal_ips[0]} --from-literal=public-ip=$public_ip --from-literal=garden-rootfs-driver=overlay-xfs
-cat persistent-sc.yaml cap-psp-rbac.yaml cluster-admin.yaml | docker run --rm -i -v $KUBECONFIG:/root/.kube/config splatform/cf-ci-orchestration kubectl create -f -
+cat persistent-sc.yaml cluster-admin.yaml | docker run --rm -i -v $KUBECONFIG:/root/.kube/config splatform/cf-ci-orchestration kubectl create -f -
 docker run --rm -it -v $KUBECONFIG:/root/.kube/config splatform/cf-ci-orchestration helm init


### PR DESCRIPTION
This PR supersedes https://github.com/SUSE/cf-ci/pull/199

```
- Create privileged and unprivileged PSPs
- Link to both in deploy parameters for CAP >= 2.14.5
- Create legacy privileged CRB for default SAs in CAP < 2.14.5
```

Changes on the new branch include:
- Based on current master with new notification changes (work from previous branch, `harts-use-privileged-and-unprivileged-psp` has been cherry-picked)
- Upon discussion with @bikramnehra renamed cap-psp-unprivileged.yaml -> cap-psp-nonprivileged.yaml, the psp name cap.psp.unprivileged -> cap.psp.nonprivileged (and updated references in other files accordingly). `unprivileged` sounds more natural to me, but since the helm param to CAP is `nonprivileged` we should stick with that for consistency.
- Fixed the accidental inversion of the psp names when passing them to helm params (which caused failures in previous tests)