### PR TITLE
Improve swapaccounting enablement in deploy-aks.sh

### DIFF
--- a/qa-tools/deploy-aks.sh
+++ b/qa-tools/deploy-aks.sh
@@ -85,8 +85,8 @@ export AZ_MC_RG_NAME=$(az group list -o table | grep MC_"$AZ_RG_NAME"_ | awk '{p
 vmnodes=$(az vm list -g $AZ_MC_RG_NAME | jq -r '.[] | select (.tags.poolName | contains("node")) | .name')
 for i in $vmnodes; do
    az vm run-command invoke -g $AZ_MC_RG_NAME -n $i --command-id RunShellScript \
-     --scripts "sudo sed -i 's|linux.*./boot/vmlinuz-.*|& swapaccount=1|' /boot/grub/grub.cfg"
-   sleep 1 # avoid a weird timing issue?
+     --scripts "sudo sed -i -r 's|^(GRUB_CMDLINE_LINUX_DEFAULT=)\"(.*.)\"|\1\"\2 swapaccount=1\"|' /etc/default/grub.d/50-cloudimg-settings.cfg"
+   az vm run-command invoke -g $AZ_MC_RG_NAME -n $i --command-id RunShellScript --scripts "sudo update-grub"
 done
 
 for i in $vmnodes; do


### PR DESCRIPTION
As pointed out in https://github.com/Azure/acs-engine/issues/3107,
adding the swapaccount parameter into the file which generates
/boot/grub/grub.cfg is safer than adding the parameter to the generated
file, because it will be overwritten when that file is regenerated