### PR TITLE
Add minibroker-redis brain test to exclude pattern

### DIFF
--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -23,7 +23,7 @@ fi
 set -o nounset
 set -o allexport
 # Set this to skip a test, e.g. 011
-EXCLUDE_BRAINS_PREFIX=011
+EXCLUDE_BRAINS_PREFIX=01[12]
 # Set this to define number of parallel ginkgo nodes in the acceptance test pod
 ACCEPTANCE_TEST_NODES=3
 CF_NAMESPACE=scf


### PR DESCRIPTION
This test is failing currently due to a client/server helm version
mismatch