### PR TITLE
Delete predefined PSPs for CAP >=2.15.1

### DIFF
--- a/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/cf-deploy-upgrade-common.sh
@@ -153,8 +153,9 @@ set_helm_params() {
         HELM_PARAMS+=(--set "kube.organization=${KUBE_ORGANIZATION}")
     fi
     HELM_PARAMS+=(--set "env.GARDEN_ROOTFS_DRIVER=${garden_rootfs_driver}")
-
-    set_psp # Sets PSP
+    if semver_is_gte 2.15.1 $(helm_chart_version); then
+        set_psp # Sets PSP
+    fi
 }
 
 set_uaa_sizing_params() {

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -16,7 +16,14 @@ set_uaa_sizing_params # Adds uaa sizing params to HELM_PARAMS
 # Delete legacy psp/crb, and set up new psps, crs, and necessary crbs for CAP version
 kubectl delete psp --ignore-not-found suse.cap.psp
 kubectl delete clusterrolebinding --ignore-not-found cap:clusterrole
-kubectl replace --force --filename=ci/qa-tools/{cap-psp-privileged,cap-psp-nonprivileged,cap-cr-privileged,cap-crb-tests}.yaml
+if semver_is_gte $(helm_chart_version) 2.15.1; then
+    kubectl delete --ignore-not-found --filename=ci/qa-tools/cap-{psp-{,non}privileged,cr-privileged-2.14.5}.yaml
+    kubectl apply --filename ci/qa-tools/cap-cr-privileged-2.15.1.yaml
+else
+    kubectl replace --force --filename=ci/qa-tools/cap-{psp-privileged,psp-nonprivileged,cr-privileged-2.14.5,crb-tests}.yaml
+fi
+
+kubectl replace --force --filename=ci/qa-tools/cap-crb-tests.yaml
 
 if semver_is_gte $(helm_chart_version) 2.14.5; then
     kubectl delete --ignore-not-found --filename ci/qa-tools/cap-crb-2.13.3.yaml

--- a/qa-pipelines/tasks/cf-teardown.sh
+++ b/qa-pipelines/tasks/cf-teardown.sh
@@ -33,7 +33,8 @@ for namespace in "$CF_NAMESPACE" "$UAA_NAMESPACE" ; do
 done
 
 kubectl delete --ignore-not-found \
-    --filename ci/qa-tools/cap-cr-privileged.yaml \
+    --filename ci/qa-tools/cap-cr-privileged-2.14.5.yaml \
+    --filename ci/qa-tools/cap-cr-privileged-2.15.1.yaml \
     --filename ci/qa-tools/cap-crb-2.13.3.yaml \
     --filename ci/qa-tools/cap-crb-tests.yaml \
     --filename ci/qa-tools/cap-psp-nonprivileged.yaml \

--- a/qa-tools/cap-cr-privileged-2.14.5.yaml
+++ b/qa-tools/cap-cr-privileged-2.14.5.yaml
@@ -8,4 +8,3 @@ rules:
     resources: ['podsecuritypolicies']
     verbs: ['use']
     resourceNames: ['suse.cap.psp.privileged']
-

--- a/qa-tools/cap-cr-privileged-2.15.1.yaml
+++ b/qa-tools/cap-cr-privileged-2.15.1.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: suse:cap:psp:privileged
+rules:
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['scf-psp-privileged']


### PR DESCRIPTION
This verifies that charts now create necessary PSP defaults