### PR TITLE
AKS deploy updates:

### DIFF
--- a/qa-tools/deploy-aks.sh
+++ b/qa-tools/deploy-aks.sh
@@ -54,7 +54,7 @@ az group create --name $AZ_RG_NAME --location $AZ_REGION
 az aks create --resource-group $AZ_RG_NAME --name $AZ_AKS_NAME \
               --node-count $AZ_AKS_NODE_COUNT --admin-username $AZ_ADMIN_USER \
               --ssh-key-value ${AZ_SSH_KEY}.pub --node-vm-size $AZ_AKS_NODE_VM_SIZE \
-              --node-osdisk-size 60 --kubernetes-version 1.11.6
+              --node-osdisk-size 60 --kubernetes-version 1.11.8
 
 export KUBECONFIG=$(mktemp -d)/config
 

--- a/qa-tools/deploy-aks.sh
+++ b/qa-tools/deploy-aks.sh
@@ -43,7 +43,7 @@ export AZ_RG_NAME=${az_user_prefix}cap-aks
 export AZ_AKS_NAME=$AZ_RG_NAME
 export AZ_REGION=eastus
 export AZ_AKS_NODE_COUNT=3
-export AZ_AKS_NODE_VM_SIZE=Standard_DS3_v2
+export AZ_AKS_NODE_VM_SIZE=Standard_DS4_v2
 export AZ_ADMIN_USER=scf-admin
 export AZ_SSH_KEY_PATH=$(mktemp -d)
 export AZ_SSH_KEY=${AZ_SSH_KEY_PATH}/aks-deploy
@@ -54,7 +54,7 @@ az group create --name $AZ_RG_NAME --location $AZ_REGION
 az aks create --resource-group $AZ_RG_NAME --name $AZ_AKS_NAME \
               --node-count $AZ_AKS_NODE_COUNT --admin-username $AZ_ADMIN_USER \
               --ssh-key-value ${AZ_SSH_KEY}.pub --node-vm-size $AZ_AKS_NODE_VM_SIZE \
-              --node-osdisk-size 60 --kubernetes-version 1.11.5
+              --node-osdisk-size 60 --kubernetes-version 1.11.6
 
 export KUBECONFIG=$(mktemp -d)/config
 

--- a/qa-tools/persistent-sc.yaml
+++ b/qa-tools/persistent-sc.yaml
@@ -2,14 +2,11 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"storage.k8s.io/v1beta1","kind":"StorageClass","metadata":{"labels":{"kubernetes.io/cluster-service":"true"},"name":"persistent","namespace":""},"parameters":{"kind":"Managed","storageaccounttype":"Standard_LRS"},"provisioner":"kubernetes.io/azure-disk"}
   labels:
     kubernetes.io/cluster-service: "true"
   name: persistent
 parameters:
   kind: Managed
-  storageaccounttype: Standard_LRS
+  storageaccounttype: Premium_LRS
 provisioner: kubernetes.io/azure-disk
 reclaimPolicy: Delete


### PR DESCRIPTION
- Use kube version 1.11.6. 1.11.5 is no longer supported
- Increase node type to DS4_v2 since DS3_v2 is no longer sufficient
- Use Persistent storageclass instead of Standard