### PR TITLE
Adding minibroker chart extractor

### DIFF
--- a/automation-scripts/minibroker-charts/extractor.py
+++ b/automation-scripts/minibroker-charts/extractor.py
@@ -14,6 +14,12 @@ from ruamel.yaml import YAML
 
 HELM_REPO_URL="https://kubernetes-charts.storage.googleapis.com/index.yaml"
 
+def create_key(arg_list):
+    """
+    Method to create key from passed args
+    """
+    return "%".join(arg_list)
+
 def process_needles():
     """
     Method to load and process known working versions in versions.yaml.
@@ -37,7 +43,7 @@ def process_haystack(databases):
     for db in databases:
         for item in data["entries"][db]:
             if "appVersion" in item and "version" in item:
-                key = db+item["appVersion"]+item["version"]
+                key = create_key([db, item["appVersion"], item["version"]])
                 haystack[key] = item
 
     return haystack
@@ -51,22 +57,26 @@ def dump_yaml(data):
         yaml.dump(data, outfile)
 
 def main():
-    needles = process_needles()
-    databases = needles.keys()
-    haystack = process_haystack(databases)
-    output = {}
-    for db in databases:
-        for item in needles[db]:
-            needle = db+item["appVersion"]+item["version"]
-            # Check if provided version exists in helm stable repo.
-            if needle in haystack:
-                if db not in output:
-                    output[db] = [haystack[needle]]
-                else:
-                    output[db].append(haystack[needle])
+    if len(argv) < 3:
+        print("Please provide correct arguments...")
+        print("Usage: python extractor.py <path/to/versions.yaml> <path/to/output/index.yaml>")
+    else:    
+        needles = process_needles()
+        databases = needles.keys()
+        haystack = process_haystack(databases)
+        output = {}
+        for db in databases:
+            for item in needles[db]:
+                needle = create_key([db,item["appVersion"],item["version"]])
+                # Check if provided version exists in helm stable repo.
+                if needle in haystack:
+                    if db not in output:
+                        output[db] = [haystack[needle]]
+                    else:
+                        output[db].append(haystack[needle])
 
-    data = {"apiVersion": "v1", "entries": output}
-    dump_yaml(data)
+        data = {"apiVersion": "v1", "entries": output}
+        dump_yaml(data)
 
 if __name__ == "__main__":
     main()

--- a/automation-scripts/minibroker-charts/extractor.py
+++ b/automation-scripts/minibroker-charts/extractor.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+# Script to extract working versions of minibroker database charts from helm stable repo's index.yaml.
+# Make sure the YAML parsing lib is installed: `pip install ruamel.yaml`.
+# 
+# Usage:
+# 1. Update the versions.yaml with the minibroker DB versions known to be working with current CAP release.
+# 2. Run `python extractor.py`
+
+import os
+from ruamel.yaml import YAML
+
+os.system("curl -s https://kubernetes-charts.storage.googleapis.com/index.yaml > helm_stable_index.yaml")
+
+def read_yaml(file):
+    try:
+        with open(file, 'r') as stream:
+            yaml = YAML()
+            return yaml.load(stream)
+    except yaml.YAMLError as exc:
+        print(exc)
+
+all_versions = read_yaml("helm_stable_index.yaml")
+
+def dump_yaml(data):
+    with open('index.yaml', 'w') as outfile:
+        yaml = YAML()
+        data = {"apiVersion": all_versions["apiVersion"], "entries": data}
+        yaml.dump(data, outfile)
+
+def exists(db_working_versions, db_version):
+    for dwv in db_working_versions:
+        if "version" in db_version and "appVersion" in db_version:
+            if dwv["appVersion"] == db_version["appVersion"] \
+                and dwv["version"] == db_version["version"]:
+                    return True
+
+def main():
+    entries = {}
+    working_versions = read_yaml("versions.yaml")
+
+    for db in working_versions:
+        temp_list = []
+        db_working_versions = working_versions[db]
+        for db_version in all_versions["entries"][db]:
+            if exists(db_working_versions, db_version):
+                temp_list.append(db_version)
+        entries[db] = temp_list
+    
+    dump_yaml(entries)
+
+if __name__ == "__main__":
+    main()
+    

--- a/automation-scripts/minibroker-charts/versions.yaml
+++ b/automation-scripts/minibroker-charts/versions.yaml
@@ -1,0 +1,37 @@
+mariadb:
+  -
+    appVersion: 10.1.34
+    version: 4.3.0
+mongodb:
+  -
+    appVersion: 3.6.6
+    version: 4.0.2
+postgresql:
+  -
+    appVersion: 10.7.0
+    version: 3.16.1
+  - 
+    appVersion: 10.6.0
+    version: 3.11.0
+  - 
+    appVersion: 10.5.0
+    version: 2.3.3
+  - 
+    appVersion: 9.6.2
+    version: 1.0.0
+redis:
+  - 
+    appVersion: 4.0.14
+    version: 6.4.4
+  - 
+    appVersion: 4.0.13
+    version: 6.4.1
+  - 
+    appVersion: 4.0.12
+    version: 6.1.1
+  -
+    appVersion: 4.0.11
+    version: 5.1.1
+  - 
+    appVersion: 4.0.10
+    version: 3.7.2


### PR DESCRIPTION
## Description

Script to extract versions of minibroker databases known to be working with CAP.

**Details:** https://trello.com/c/iIrYZZY7/1068-5-curate-minibroker-service-plans-that-work-with-cap

## Test plan

Run `python extractor.py <path/to/versions.yaml> <path/to/output/index.yaml>` and check the generated `index.yaml`
