### PR TITLE
Avoid erb setting '' when we want '""' in yaml

### DIFF
--- a/qa-pipelines/qa-pipeline.yml.erb
+++ b/qa-pipelines/qa-pipeline.yml.erb
@@ -4,8 +4,8 @@
 
 def bundle_url_from_version(version)
   case version
-    when true    then ''      # Use bucket version
-    when false   then ''      # Don't install (non-upgrade pipelines, for example)
+    when true    then '""'      # Use bucket version
+    when false   then '""'      # Don't install (non-upgrade pipelines, for example)
     when /:\/\// then version # URL
     else "https://((s3-config-bucket-sles)).s3.amazonaws.com/((s3-config-prefix-sles))#{ERB::Util.url_encode(version)}.zip"
   end


### PR DESCRIPTION
Setting nothing in the post-templating yaml for a key value (a task
parameter in this case) results in that being considered a 'null' value
in yaml, which concourse sets literally, which then becomes the string
"null" in the bash environment. Instead, we want the generated yaml to
include a literal '""' to indicate an empty string