### PR TITLE
jq -r to get lb_ip lb_hostname as raw string

### DIFF
--- a/qa-pipelines/tasks/lib/azure-aks.sh
+++ b/qa-pipelines/tasks/lib/azure-aks.sh
@@ -79,8 +79,8 @@ azure_wait_for_lbs_in_namespace() {
 }
 
 azure_set_record() {
-    local lb_hostname=$(jq .hostname <<< $2)
-    local lb_ip=$(jq .ip <<< $2)
+    local lb_hostname=$(jq -r .hostname <<< $2)
+    local lb_ip=$(jq -r .ip <<< $2)
     if [[ ${cap_platform} == "eks" ]]; then
         az network dns record-set cname create \
             --resource-group ${AZURE_DNS_RESOURCE_GROUP} \


### PR DESCRIPTION
Bug fix
```
 az network dns record-set a add-record --resource-group susecap-domain --zone-name susecap.net --record-set-name uaa.psharma4-cap-aks --ipv4-address '"40.76.13.134"'
Operation failed with status: 'Bad Request'. Details: The provided ip address '"40.76.13.134"' is not valid.
```