### PR TITLE
fix bundle_url

### DIFF
--- a/qa-pipelines/config-azure.yml
+++ b/qa-pipelines/config-azure.yml
@@ -23,4 +23,3 @@ organization: splatform
 magic-dns-service: omg.howdoi.website
 
 src-repo: SUSE/scf
-cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f.zip

--- a/qa-pipelines/config-capci.yml
+++ b/qa-pipelines/config-capci.yml
@@ -23,4 +23,3 @@ organization: splatform
 magic-dns-service: omg.howdoi.website
 
 src-repo: SUSE/scf
-cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f.zip

--- a/qa-pipelines/config-ecp.yml
+++ b/qa-pipelines/config-ecp.yml
@@ -23,4 +23,3 @@ organization: splatform
 magic-dns-service: omg.howdoi.website
 
 src-repo: SUSE/scf
-cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f.zip

--- a/qa-pipelines/config-eks.yml
+++ b/qa-pipelines/config-eks.yml
@@ -23,4 +23,3 @@ organization: splatform
 magic-dns-service: omg.howdoi.website
 
 src-repo: SUSE/scf
-cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f.zip

--- a/qa-pipelines/config-gke.yml
+++ b/qa-pipelines/config-gke.yml
@@ -23,4 +23,3 @@ organization: splatform
 magic-dns-service: omg.howdoi.website
 
 src-repo: SUSE/scf
-cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f.zip

--- a/qa-pipelines/config-provo.yml
+++ b/qa-pipelines/config-provo.yml
@@ -23,4 +23,3 @@ organization: splatform
 magic-dns-service: omg.howdoi.website
 
 src-repo: SUSE/scf
-cap-sle-url: https://s3.amazonaws.com/cap-release-archives/master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f.zip

--- a/qa-pipelines/flags.yml
+++ b/qa-pipelines/flags.yml
@@ -8,7 +8,7 @@
 status-reporting: true
 
 # version to upgrade from; if null, upgrade is not performed.
-enable-cf-deploy-pre-upgrade: scf-sle-2.15.2+cf3.6.0.0.gde1bd02f
+enable-cf-deploy-pre-upgrade: master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f
 
 # When upgrading, deploy cf-usb (and an app using it) pre-upgrade, and ensure
 # that it remains working post-upgrade

--- a/qa-pipelines/pipeline-presets/upgrades-NoUsb-NoBrains.yml
+++ b/qa-pipelines/pipeline-presets/upgrades-NoUsb-NoBrains.yml
@@ -1,6 +1,6 @@
 ---
 
-enable-cf-deploy-pre-upgrade: scf-sle-2.15.2+cf3.6.0.0.gde1bd02f
+enable-cf-deploy-pre-upgrade: master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f
 
 enable-cf-smoke-tests-pre-upgrade: true
 

--- a/qa-pipelines/pipeline-presets/upgrades-NoUsb-NoCats.yml
+++ b/qa-pipelines/pipeline-presets/upgrades-NoUsb-NoCats.yml
@@ -1,6 +1,6 @@
 ---
 
-enable-cf-deploy-pre-upgrade: scf-sle-2.15.2+cf3.6.0.0.gde1bd02f
+enable-cf-deploy-pre-upgrade: master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f
 
 enable-cf-smoke-tests-pre-upgrade: true
 enable-cf-brain-tests-pre-upgrade: true

--- a/qa-pipelines/pipeline-presets/upgrades-NoUsb.yml
+++ b/qa-pipelines/pipeline-presets/upgrades-NoUsb.yml
@@ -1,6 +1,6 @@
 ---
 
-enable-cf-deploy-pre-upgrade: scf-sle-2.15.2+cf3.6.0.0.gde1bd02f
+enable-cf-deploy-pre-upgrade: master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f
 
 enable-cf-smoke-tests-pre-upgrade: true
 enable-cf-brain-tests-pre-upgrade: true

--- a/qa-pipelines/pipeline-presets/upgrades-lite.yml
+++ b/qa-pipelines/pipeline-presets/upgrades-lite.yml
@@ -1,6 +1,6 @@
 ---
 
-enable-cf-deploy-pre-upgrade: scf-sle-2.15.2+cf3.6.0.0.gde1bd02f
+enable-cf-deploy-pre-upgrade: master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f
 
 enable-cf-smoke-tests-pre-upgrade: true
 

--- a/qa-pipelines/qa-pipeline.yml.erb
+++ b/qa-pipelines/qa-pipeline.yml.erb
@@ -7,7 +7,7 @@ def bundle_url_from_version(version)
     when true    then '""'      # Use bucket version
     when false   then '""'      # Don't install (non-upgrade pipelines, for example)
     when /:\/\// then version # URL
-    else "https://((s3-config-bucket-sles)).s3.amazonaws.com/((s3-config-prefix-sles))#{ERB::Util.url_encode(version)}.zip"
+    else "https://((s3-config-bucket-sles)).s3.amazonaws.com/#{(version)}.zip"
   end
 end
 


### PR DESCRIPTION
- replace ((s3-config-prefix-sles)) to `master` in  bundle_url as otherwise it uses nightly bucket for master build when --nightly flag is used in upgrades CI
- update upgrade version from 2.15.2 to 2.16.4
- remove cap-sle-url from config-{pool}.yml(s)