### PR TITLE
Fix wait_for_jobs

### DIFF
--- a/qa-pipelines/tasks/lib/azure-aks.sh
+++ b/qa-pipelines/tasks/lib/azure-aks.sh
@@ -21,7 +21,7 @@ az_login() {
 AZURE_DNS_ZONE_NAME=susecap.net
 AZURE_DNS_RESOURCE_GROUP=susecap-domain
 if grep "eks.amazonaws.com" ~/.kube/config; then
-    AZURE_AKS_RESOURCE_GROUP=$(y2j ~/.kube/config | jq -r .[0]..clusters[0].name | cut -d / -f 2)
+    AZURE_AKS_RESOURCE_GROUP=$(y2j ~/.kube/config | jq -r .[0].clusters[0].name | cut -d / -f 2)
 else
     AZURE_AKS_RESOURCE_GROUP=$(kubectl get configmap -n kube-system -o json cap-values | jq -r '.data["resource-group"]')
 fi

--- a/qa-pipelines/tasks/lib/azure-aks.sh
+++ b/qa-pipelines/tasks/lib/azure-aks.sh
@@ -2,9 +2,13 @@
 
 set -eu # errexit, nounset
 
-# Outputs a json representation of a yml document. For multi-document files, only the first document will be converted
+# Outputs a json representation of a yml document
 y2j() {
-    ruby -r json/ext -r yaml -e "puts YAML.load_file('$1').to_json"
+    if [[ -e ${1:-} ]]; then
+        ruby -r json -r yaml -e "puts YAML.load_stream(File.read('$1')).to_json"
+    else
+        ruby -r json -r yaml -e 'puts (YAML.load_stream(ARGF.read).to_json)'
+    fi
 }
 
 az_login() {
@@ -17,7 +21,7 @@ az_login() {
 AZURE_DNS_ZONE_NAME=susecap.net
 AZURE_DNS_RESOURCE_GROUP=susecap-domain
 if grep "eks.amazonaws.com" ~/.kube/config; then
-    AZURE_AKS_RESOURCE_GROUP=$(y2j ~/.kube/config | jq -r .clusters[0].name | cut -d / -f 2)
+    AZURE_AKS_RESOURCE_GROUP=$(y2j ~/.kube/config | jq -r .[0]..clusters[0].name | cut -d / -f 2)
 else
     AZURE_AKS_RESOURCE_GROUP=$(kubectl get configmap -n kube-system -o json cap-values | jq -r '.data["resource-group"]')
 fi

--- a/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
@@ -82,7 +82,7 @@ wait_for_jobs() {
         echo "waiting for job ${job}"
         seconds_remaining=$(( 4800 + ${start} - $(date +%s) ))
         set +o errexit 
-        kubectl wait job --namespace ${namespace} --for=condition=complete --timeout ${seconds_remaining}s
+        kubectl wait job ${job} --namespace ${namespace} --for=condition=complete --timeout ${seconds_remaining}s
         kubectl_wait_status=$?
         set -o errexit 
         time_since_start=$(( $(date +%s) - ${start} ))

--- a/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
@@ -63,9 +63,13 @@ is_namespace_ready() {
         | uniq) ]]
 }
 
+# Outputs a json representation of a yml document
 y2j() {
-    # Parses YAML input as a stream from stdin and outputs JSON
-    ruby -r json -r yaml -e 'puts (YAML.load_stream(ARGF.read).to_json)'
+    if [[ -e ${1:-} ]]; then
+        ruby -r json -r yaml -e "puts YAML.load_stream(File.read('$1')).to_json"
+    else
+        ruby -r json -r yaml -e 'puts (YAML.load_stream(ARGF.read).to_json)'
+    fi
 }
 
 wait_for_jobs() {

--- a/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
@@ -87,7 +87,7 @@ wait_for_jobs() {
         set -o errexit 
         time_since_start=$(( $(date +%s) - ${start} ))
         if [[ ${kubectl_wait_status} -eq 0 ]]; then
-            echo "Done waiting for ${release} jobs at $(date --rfc-2822) (${time_since_start})s)"
+            echo "Done waiting for ${release} jobs at $(date --rfc-2822) (${time_since_start}s)"
         elif [[ ${time_since_start} -ge 4800 ]]; then  
             echo "${release} job ${job} not completed due to timeout"
             return 1


### PR DESCRIPTION
This bypasses potential issues due to 'helm status' output variability. From a previous comment in the `wait_for_job` function:

```
wait_for_jobs()
        # Get the list of all jobs in the helm release, and subtract the value of 'completed' from 'desired'
        # It would be better to parse this from `helm get manifest`, but since that command is broken in helm
        # v2.8.2 (https://github.com/helm/helm/issues/3833) for now we'll parse it from the human-readable status
...
```

Since we've updated helm and kubectl versions in our cf-ci-orchestration image, we can now wait for jobs to complete in a more stable way (`kubectl watch` is now supported)