### PR TITLE
Add cf-upgrade flag and adjust template tasks

### DIFF
--- a/qa-pipelines/flags.yml
+++ b/qa-pipelines/flags.yml
@@ -10,18 +10,20 @@ status-reporting: true
 # version to upgrade from; if null, upgrade is not performed.
 enable-cf-deploy-pre-upgrade: master/scf-sle-2.16.4%2Bcf6.10.0.2.g5abdb16f
 
-# When upgrading, deploy cf-usb (and an app using it) pre-upgrade, and ensure
-# that it remains working post-upgrade
-enable-cf-usb-upgrade-tests: true
-
 # run tests before an upgrade
 enable-cf-smoke-tests-pre-upgrade: true
 enable-cf-brain-tests-pre-upgrade: true
 
+# When upgrading, deploy cf-usb (and an app using it) pre-upgrade, and ensure
+# that it remains working post-upgrade
+enable-cf-usb-upgrade-tests: true
+enable-cf-upgrade: true
+# USB post-upgrade task will run after upgrade when upgrade-tests flag is enabled
+
 # Deploy CF for pipelines.  If upgrade-from-version is set, this triggers an
 # upgrade instead.  This may be `true` (use the latest in the bucket), `false`
 # (don't deploy), or a string (in which case use given bundle URL)
-enable-cf-deploy: true
+enable-cf-deploy: false
 
 # run tests for non-upgrade pipelines, and post-upgrade tests for upgrade pipelines
 enable-cf-smoke-tests: true

--- a/qa-pipelines/qa-pipeline.yml.erb
+++ b/qa-pipelines/qa-pipeline.yml.erb
@@ -139,8 +139,6 @@ jobs:
       params: {release: pool.kube-hosts}
   - do:
     <% if enable_cf_deploy_pre_upgrade %>
-    # This section only exists for upgrade pipelines; it determines how to set
-    # up the pre-upgrade deployment.
     - task: cf-deploy-pre-upgrade
       file: ci/qa-pipelines/tasks/cf-deploy.yml
       params:
@@ -148,12 +146,7 @@ jobs:
         HA: <%= avail == 'HA' %>
       input_mapping:
         s3.scf-config: s3.scf-config-sles
-    <% if enable_cf_usb_upgrade_tests %>
-    - task: usb-deploy-pre-upgrade
-      file: ci/qa-pipelines/tasks/usb-deploy.yml
-      params:
-        GKE_PRIVATE_KEY_BASE64: ((gke-private-key-base64))
-    <% end %> # enable_cf_usb_upgrade_tests
+    <% end %> # enable_cf_deploy_pre_upgrade
     <% if enable_cf_smoke_tests_pre_upgrade %>
     - task: cf-smoke-tests-pre-upgrade
       file: ci/qa-pipelines/tasks/run-test.yml
@@ -172,7 +165,14 @@ jobs:
       input_mapping:
         s3.scf-config: s3.scf-config-sles
     <% end %> # enable_cf_brain_tests_pre_upgrade
-    <% if enable_cf_deploy %>
+    <% if enable_cf_usb_upgrade_tests %>
+    - task: usb-deploy-pre-upgrade
+      file: ci/qa-pipelines/tasks/usb-deploy.yml
+      params:
+        << : *upgrade-task-params
+        GKE_PRIVATE_KEY_BASE64: ((gke-private-key-base64))
+    <% end %> # enable_cf_usb_upgrade_tests
+    <% if enable_cf_upgrade %>
     - task: cf-upgrade
       file: ci/qa-pipelines/tasks/cf-upgrade.yml
       params:
@@ -180,13 +180,12 @@ jobs:
         HA: <%= avail == 'HA' %>
       input_mapping:
         s3.scf-config: s3.scf-config-sles
-    <% end %> # enable_cf_deploy
+    <% end %> # enable_cf_upgrade
     <% if enable_cf_usb_upgrade_tests %>
     - task: usb-post-upgrade
       file: ci/qa-pipelines/tasks/usb-post-upgrade.yml
       params: *common-task-params
     <% end %> # enable_cf_usb_upgrade_tests
-    <% else %> # enable_cf_deploy_pre_upgrade
     # When this is _not_ an upgrade pipeline, we may wish to deploy CF before
     # running the tests.
     <% if enable_cf_deploy %>
@@ -198,7 +197,6 @@ jobs:
       input_mapping:
         s3.scf-config: s3.scf-config-sles
     <% end %> # enable_cf_deploy
-    <% end %> # enable_cf_deploy_pre_upgrade
     <% if enable_cf_smoke_tests %>
     - task: cf-smoke-tests
       file: ci/qa-pipelines/tasks/run-test.yml


### PR DESCRIPTION
Our template file omitted the cf-upgrade task, and also lost some of the
granularity we had prior to the templating, by assuming all pipelines
would be either full upgrade or start from non-upgrade deploy. This work
adds the cf-upgrade task back and allows pipelines to start from
pre-upgrade tasks (without pre-upgrade deploy, for situations where we
want to test and upgrade an existing CAP deployment)