### PR TITLE
Specify org for cf login in usb-deploy task

### DIFF
--- a/qa-pipelines/tasks/usb-deploy.sh
+++ b/qa-pipelines/tasks/usb-deploy.sh
@@ -107,7 +107,7 @@ COMMON_SIDECAR_PARAMS=(
 )
 
 cf api --skip-ssl-validation "https://api.${DOMAIN}"
-cf login -u admin -p changeme
+cf login -u admin -p changeme -o system
 cf create-org usb-test-org
 cf create-space -o usb-test-org usb-test-space
 cf target -o usb-test-org -s usb-test-space


### PR DESCRIPTION
When more than one org exists on the CAP deployment, attemping to cf
login without providing the org will trigger an interactive prompt,
breaking automation