### PR TITLE
qa-pipelines: support embedded UAA

### DIFF
--- a/qa-pipelines/pipeline-presets/embedded-uaa.yml
+++ b/qa-pipelines/pipeline-presets/embedded-uaa.yml
@@ -8,22 +8,22 @@
 enable-terraform: true
 
 # Report status as steps complete
-status-reporting: true
+status-reporting: false
 
 # version to upgrade from; if null, upgrade is not performed.
-enable-cf-deploy-pre-upgrade: master/scf-sle-2.17.1%2Bcf7.11.0.4.ga6c993eb
+enable-cf-deploy-pre-upgrade: develop/scf-sle-2.17.1%2Bcf7.11.0.93.g6192712d
 
 # When deploying / upgrading, use the embedded UAA instead of the normal,
 # separately namespaced UAA.
-enable-embedded-uaa: false
+enable-embedded-uaa: true
 
 # run tests before an upgrade
 enable-cf-smoke-tests-pre-upgrade: true
-enable-cf-brain-tests-pre-upgrade: true
+enable-cf-brain-tests-pre-upgrade: false
 
 # When upgrading, deploy cf-usb (and an app using it) pre-upgrade, and ensure
 # that it remains working post-upgrade
-enable-cf-usb-upgrade-tests: true
+enable-cf-usb-upgrade-tests: false
 enable-cf-upgrade: true
 # USB post-upgrade task will run after upgrade when upgrade-tests flag is enabled
 
@@ -34,8 +34,8 @@ enable-cf-deploy: false
 
 # run tests for non-upgrade pipelines, and post-upgrade tests for upgrade pipelines
 enable-cf-smoke-tests: true
-enable-cf-brain-tests: true
-enable-cf-acceptance-tests: true
+enable-cf-brain-tests: false
+enable-cf-acceptance-tests: false
 
 # tear down CAP deployment when all tasks are successful
 enable-cf-teardown: true

--- a/qa-pipelines/qa-pipeline.yml.erb
+++ b/qa-pipelines/qa-pipeline.yml.erb
@@ -176,6 +176,7 @@ jobs:
       params:
         << : *upgrade-task-params
         HA: <%= avail == 'HA' %>
+        EMBEDDED_UAA: ((enable-embedded-uaa))
       input_mapping:
         s3.scf-config: s3.scf-config-sles
     <% end %> # enable_cf_deploy_pre_upgrade
@@ -209,6 +210,7 @@ jobs:
       params:
         << : *common-task-params
         HA: <%= avail == 'HA' %>
+        EMBEDDED_UAA: ((enable-embedded-uaa))
       input_mapping:
         s3.scf-config: s3.scf-config-sles
     <% end %> # enable_cf_upgrade
@@ -225,6 +227,7 @@ jobs:
       params:
         << : *common-task-params
         HA: <%= avail == 'HA' %>
+        EMBEDDED_UAA: ((enable-embedded-uaa))
       input_mapping:
         s3.scf-config: s3.scf-config-sles
     <% end %> # enable_cf_deploy

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -66,7 +66,7 @@ if [[ ${PROVISIONER} == kubernetes.io/rbd ]]; then
     kubectl get secret -o yaml ceph-secret-admin | sed "s/namespace: default/namespace: ${CF_NAMESPACE}/g" | kubectl create -f -
 fi
 
-if [ "${EMBEDDED_UAA:-false}" = "true" ]; then
+if [[ "${EMBEDDED_UAA:-false}" == "true" ]]; then
     HELM_PARAMS+=(--set "enable.uaa=true")
 else
     HELM_PARAMS+=(--set "secrets.UAA_CA_CERT=$(get_uaa_ca_cert)")

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -30,7 +30,7 @@ fi
 echo UAA customization ...
 echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
 
-if [ "${EMBEDDED_UAA:-false}" != "true" ]; then
+if [[ "${EMBEDDED_UAA:-false}" != "true" ]]; then
     # Deploy UAA
     kubectl create namespace "${UAA_NAMESPACE}"
     if [[ "${PROVISIONER}" == "kubernetes.io/rbd" ]]; then

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -30,31 +30,31 @@ fi
 echo UAA customization ...
 echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
 
-# Deploy UAA
-kubectl create namespace "${UAA_NAMESPACE}"
-if [[ "${PROVISIONER}" == "kubernetes.io/rbd" ]]; then
-    kubectl get secret -o yaml ceph-secret-admin | sed "s/namespace: default/namespace: ${UAA_NAMESPACE}/g" | kubectl create -f -
-fi
+if [ "${EMBEDDED_UAA:-false}" != "true" ]; then
+    # Deploy UAA
+    kubectl create namespace "${UAA_NAMESPACE}"
+    if [[ "${PROVISIONER}" == "kubernetes.io/rbd" ]]; then
+        kubectl get secret -o yaml ceph-secret-admin | sed "s/namespace: default/namespace: ${UAA_NAMESPACE}/g" | kubectl create -f -
+    fi
 
-helm install ${CAP_DIRECTORY}/helm/uaa/ \
-    --namespace "${UAA_NAMESPACE}" \
-    --name uaa \
-    --timeout 600 \
-    "${HELM_PARAMS[@]}"
+    helm install ${CAP_DIRECTORY}/helm/uaa/ \
+        --namespace "${UAA_NAMESPACE}" \
+        --name uaa \
+        --timeout 600 \
+        "${HELM_PARAMS[@]}"
 
-# Wait for UAA release
-wait_for_release uaa
+    # Wait for UAA release
+    wait_for_release uaa
 
-if [[ ${cap_platform} =~ ^azure$|^gke$|^eks$ ]]; then
-    az_login
-    azure_dns_clear
-    azure_wait_for_lbs_in_namespace uaa
-    azure_set_record_sets_for_namespace uaa
+    if [[ ${cap_platform} =~ ^azure$|^gke$|^eks$ ]]; then
+        az_login
+        azure_dns_clear
+        azure_wait_for_lbs_in_namespace uaa
+        azure_set_record_sets_for_namespace uaa
+    fi
 fi
 
 # Deploy CF
-CA_CERT="$(get_internal_ca_cert)"
-
 set_helm_params # Resets HELM_PARAMS
 set_scf_sizing_params # Adds scf sizing params to HELM_PARAMS
 
@@ -66,6 +66,12 @@ if [[ ${PROVISIONER} == kubernetes.io/rbd ]]; then
     kubectl get secret -o yaml ceph-secret-admin | sed "s/namespace: default/namespace: ${CF_NAMESPACE}/g" | kubectl create -f -
 fi
 
+if [ "${EMBEDDED_UAA:-false}" = "true" ]; then
+    HELM_PARAMS+=(--set "enable.uaa=true")
+else
+    HELM_PARAMS+=(--set "secrets.UAA_CA_CERT=$(get_uaa_ca_cert)")
+fi
+
 helm install ${CAP_DIRECTORY}/helm/cf/ \
     --namespace "${CF_NAMESPACE}" \
     --name scf \
@@ -73,7 +79,6 @@ helm install ${CAP_DIRECTORY}/helm/cf/ \
     --set "secrets.CLUSTER_ADMIN_PASSWORD=${CLUSTER_ADMIN_PASSWORD:-changeme}" \
     --set "env.UAA_HOST=${UAA_HOST}" \
     --set "env.UAA_PORT=${UAA_PORT}" \
-    --set "secrets.UAA_CA_CERT=${CA_CERT}" \
     --set "env.SCF_LOG_HOST=${SCF_LOG_HOST}" \
     --set "env.INSECURE_DOCKER_REGISTRIES=${INSECURE_DOCKER_REGISTRIES}" \
     "${HELM_PARAMS[@]}"

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -66,9 +66,7 @@ if [[ ${PROVISIONER} == kubernetes.io/rbd ]]; then
     kubectl get secret -o yaml ceph-secret-admin | sed "s/namespace: default/namespace: ${CF_NAMESPACE}/g" | kubectl create -f -
 fi
 
-if [[ "${EMBEDDED_UAA:-false}" == "true" ]]; then
-    HELM_PARAMS+=(--set "enable.uaa=true")
-else
+if [[ "${EMBEDDED_UAA:-false}" != "true" ]]; then
     HELM_PARAMS+=(--set "secrets.UAA_CA_CERT=$(get_uaa_ca_cert)")
 fi
 

--- a/qa-pipelines/tasks/cf-deploy.yml
+++ b/qa-pipelines/tasks/cf-deploy.yml
@@ -18,6 +18,7 @@ params:
   HA: false # true, false, or "scaled"
   MAGIC_DNS_SERVICE: xip.io
   CAP_BUNDLE_URL: ""
+  EMBEDDED_UAA: false # true or false
 
 run:
   path: ci/qa-pipelines/tasks/cf-deploy.sh

--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -52,24 +52,30 @@ set_uaa_sizing_params # Adds uaa sizing params to HELM_PARAMS
 echo UAA customization ...
 echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
 
-helm upgrade uaa ${CAP_DIRECTORY}/helm/uaa/ \
-    --namespace "${UAA_NAMESPACE}" \
-    --recreate-pods \
-    --timeout 3600 \
-    --wait \
-    "${HELM_PARAMS[@]}"
+if [ "${EMBEDDED_UAA:-false}" != "true" ]; then
+  helm upgrade uaa ${CAP_DIRECTORY}/helm/uaa/ \
+      --namespace "${UAA_NAMESPACE}" \
+      --recreate-pods \
+      --timeout 3600 \
+      --wait \
+      "${HELM_PARAMS[@]}"
 
-# Wait for UAA release
-wait_for_release uaa
+  # Wait for UAA release
+  wait_for_release uaa
+fi
 
 # Deploy CF
-CA_CERT="$(get_internal_ca_cert)"
-
 set_helm_params # Resets HELM_PARAMS
 set_scf_sizing_params # Adds scf sizing params to HELM_PARAMS
 
 echo SCF customization ...
 echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
+
+if [ "${EMBEDDED_UAA:-false}" = "true" ]; then
+    HELM_PARAMS+=(--set "enable.uaa=true")
+else
+    HELM_PARAMS+=(--set "secrets.UAA_CA_CERT=$(get_uaa_ca_cert)")
+fi
 
 helm upgrade scf ${CAP_DIRECTORY}/helm/cf/ \
     --namespace "${CF_NAMESPACE}" \
@@ -78,7 +84,6 @@ helm upgrade scf ${CAP_DIRECTORY}/helm/cf/ \
     --set "secrets.CLUSTER_ADMIN_PASSWORD=${CLUSTER_ADMIN_PASSWORD:-changeme}" \
     --set "env.UAA_HOST=${UAA_HOST}" \
     --set "env.UAA_PORT=${UAA_PORT}" \
-    --set "secrets.UAA_CA_CERT=${CA_CERT}" \
     --set "env.SCF_LOG_HOST=${SCF_LOG_HOST}" \
     --set "env.INSECURE_DOCKER_REGISTRIES=${INSECURE_DOCKER_REGISTRIES}" \
     --wait \

--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -52,7 +52,7 @@ set_uaa_sizing_params # Adds uaa sizing params to HELM_PARAMS
 echo UAA customization ...
 echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
 
-if [ "${EMBEDDED_UAA:-false}" != "true" ]; then
+if [[ "${EMBEDDED_UAA:-false}" != "true" ]]; then
   helm upgrade uaa ${CAP_DIRECTORY}/helm/uaa/ \
       --namespace "${UAA_NAMESPACE}" \
       --recreate-pods \

--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -71,9 +71,7 @@ set_scf_sizing_params # Adds scf sizing params to HELM_PARAMS
 echo SCF customization ...
 echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
 
-if [ "${EMBEDDED_UAA:-false}" = "true" ]; then
-    HELM_PARAMS+=(--set "enable.uaa=true")
-else
+if [[ "${EMBEDDED_UAA:-false}" != "true" ]]; then
     HELM_PARAMS+=(--set "secrets.UAA_CA_CERT=$(get_uaa_ca_cert)")
 fi
 

--- a/qa-pipelines/tasks/cf-upgrade.yml
+++ b/qa-pipelines/tasks/cf-upgrade.yml
@@ -16,6 +16,7 @@ params:
   KUBE_ORGANIZATION: ""
   HA: false # true, false, or "scaled"
   MAGIC_DNS_SERVICE: xip.io
+  EMBEDDED_UAA: false # true or false
 
 run:
   path: ci/qa-pipelines/tasks/cf-upgrade.sh

--- a/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
@@ -187,19 +187,19 @@ set_helm_params() {
             HELM_PARAMS+=(--set "kube.external_ips[$i]=${external_ips[$i]}")
         done
     fi
-    if [ "${EMBEDDED_UAA:-false}" = "true" ]; then
+    if [[ "${EMBEDDED_UAA:-false}" == "true" ]]; then
         HELM_PARAMS+=(--set "enable.uaa=true")
     fi
-    if [ -n "${KUBE_REGISTRY_HOSTNAME:-}" ]; then
+    if [[ -n "${KUBE_REGISTRY_HOSTNAME:-}" ]]; then
         HELM_PARAMS+=(--set "kube.registry.hostname=${KUBE_REGISTRY_HOSTNAME%/}")
     fi
-    if [ -n "${KUBE_REGISTRY_USERNAME:-}" ]; then
+    if [[ -n "${KUBE_REGISTRY_USERNAME:-}" ]]; then
         HELM_PARAMS+=(--set "kube.registry.username=${KUBE_REGISTRY_USERNAME}")
     fi
-    if [ -n "${KUBE_REGISTRY_PASSWORD:-}" ]; then
+    if [[ -n "${KUBE_REGISTRY_PASSWORD:-}" ]]; then
         HELM_PARAMS+=(--set "kube.registry.password=${KUBE_REGISTRY_PASSWORD}")
     fi
-    if [ -n "${KUBE_ORGANIZATION:-}" ]; then
+    if [[ -n "${KUBE_ORGANIZATION:-}" ]]; then
         HELM_PARAMS+=(--set "kube.organization=${KUBE_ORGANIZATION}")
     fi
     HELM_PARAMS+=(--set "env.GARDEN_ROOTFS_DRIVER=${garden_rootfs_driver}")

--- a/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
@@ -43,7 +43,7 @@ elif [[ ${cap_platform} == "eks" ]] && kubectl get storageclass | grep gp2 > /de
     PROVISIONER=$(kubectl get storageclasses ${STORAGECLASS} -o "jsonpath={.provisioner}")
     garden_rootfs_driver="overlay-xfs"
 else
-    echo "Your k8s cluster must have a SC named persitent or gp2"
+    echo "Your k8s cluster must have a SC named persistent or gp2"
     exit 1
 fi
 
@@ -143,7 +143,7 @@ helm_chart_version() { grep "^version:"  ${CAP_DIRECTORY}/helm/uaa/Chart.yaml  |
 
 generated_secrets_secret() { kubectl get --namespace "${UAA_NAMESPACE}" secrets --output "custom-columns=:.metadata.name" | grep -F "secrets-$(helm_chart_version)-" | sort | tail -n 1 ; }
 
-get_internal_ca_cert() (
+get_uaa_ca_cert() (
     set -o pipefail
     local uaa_secret_name=$(generated_secrets_secret)
     kubectl get secret ${uaa_secret_name} \
@@ -186,6 +186,9 @@ set_helm_params() {
         for (( i=0; i < ${#external_ips[@]}; i++ )); do
             HELM_PARAMS+=(--set "kube.external_ips[$i]=${external_ips[$i]}")
         done
+    fi
+    if [ "${EMBEDDED_UAA:-false}" = "true" ]; then
+        HELM_PARAMS+=(--set "enable.uaa=true")
     fi
     if [ -n "${KUBE_REGISTRY_HOSTNAME:-}" ]; then
         HELM_PARAMS+=(--set "kube.registry.hostname=${KUBE_REGISTRY_HOSTNAME%/}")
@@ -242,19 +245,20 @@ set -o allexport
 # The external_ip is set to the internal ip of a worker node. When running on openstack or azure,
 # the public IP (used for DOMAIN) will be taken from the floating IP or load balancer IP.
 
-if [[ ${cap_platform} == openstack || ${cap_platform} == bare ]]; then
-  external_ips=($(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address'))
-  public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
-fi
+public_ip="$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"] // ""')"
 
-
-if [[ ${cap_platform} =~ ^azure$|^gke$|^eks$ ]]; then
-    source "ci/qa-pipelines/tasks/lib/azure-aks.sh"
-    DOMAIN=${AZURE_AKS_RESOURCE_GROUP}.${AZURE_DNS_ZONE_NAME}
-else
+if [[ -n "${public_ip}" ]]; then
+    # If we have a public IP in the config map, we assume this is openstack / bare metal / etc. and have
+    # external IPs hard-coded.
     # Domain for SCF. DNS for *.DOMAIN must point to the same kube node
     # referenced by external_ip.
     DOMAIN=${public_ip}.${MAGIC_DNS_SERVICE}
+    # We use external_ips in set_helm_params()
+    external_ips=($(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address'))
+else
+    # If we do _not_ have a public IP, assume this is in the cloud™ somewhere and we will use Azure DNS
+    source "ci/qa-pipelines/tasks/lib/azure-aks.sh"
+    DOMAIN=${AZURE_AKS_RESOURCE_GROUP}.${AZURE_DNS_ZONE_NAME}
 fi
 
 #Set INSECURE_DOCKER_REGISTRIES for brain test


### PR DESCRIPTION
This is basically the same as the normal pipeline, but deploys UAA as part of the SCF deployment instead of via a separate helm chart.