### PR TITLE
Open cats yamls for write and not append, allows multiple runs

### DIFF
--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -124,7 +124,7 @@ if [[ ${TEST_NAME} == "acceptance-tests-brain" ]]; then
             if doc["kind"] == "Pod"
                 File.open("${test_pod_yml}", 'w') { |file| file.write(doc.to_yaml) }
             else
-                File.open("${test_non_pods_yml}", 'a') { |file| file.write(doc.to_yaml) }
+                File.open("${test_non_pods_yml}", 'w') { |file| file.write(doc.to_yaml) }
             end
         end
 EOF


### PR DESCRIPTION
This fixes creating the yamls for `acceptance-tests-brain` test option,
so one can run the task several times and get the same files. If not,
yaml contents concatenate and give you an incorrect yaml.