### PR TITLE
[cap 370] Modified CI pipeline to set larger timeouts for CC/Broker and Brain tests

### DIFF
--- a/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
@@ -158,6 +158,16 @@ set_helm_params() {
                  --set "secrets.UAA_ADMIN_CLIENT_SECRET=${UAA_ADMIN_CLIENT_SECRET}"
                  --set "enable.autoscaler=true"
                  --set "kube.storage_class.persistent=${STORAGECLASS}")
+
+    # CAP-370. Let the CC give brokers 10 minutes to respond with
+    # their catalog. We have seen minibroker in the brain tests
+    # require 4.5 minutes to assemble such, likely due to a slow
+    # network. Doubling that should be generous enough. Together with
+    # the doubled brain test timeout (see `run-test.sh`), such tests
+    # will then still have the normal 10 minutes for any remaining
+    # actions.
+    HELM_PARAMS+=(--set "env.BROKER_CLIENT_TIMEOUT_SECONDS=600")
+
     if [[ ${cap_platform} == "eks" ]] ; then
         HELM_PARAMS+=(--set "kube.storage_class.shared=${STORAGECLASS}")
         HELM_PARAMS+=(--set "env.GARDEN_APPARMOR_PROFILE=")

--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -93,6 +93,15 @@ kube_overrides() {
                 unless include_brains_regex.empty?
                     container['env'].push name: "INCLUDE", value: include_brains_regex
                 end
+
+                # CAP-370. Extend overall brain test timeout to 20
+                # minutes. This is done to give the minibroker brain
+                # tests enough time for all their actions even when a
+                # slow network causes the broker to take up to 10
+                # minutes for the assembly/delivery of the catalog.
+                # See also `lib/cf-deploy-upgrade-common.sh` for the
+                # corresponding CC change: BROKER_CLIENT_TIMEOUT_SECONDS.
+                container['env'].push name: "TIMEOUT", value: 1200
             end
             if obj['metadata']['name'] == "acceptance-tests"
                 container['env'].push name: "CATS_SUITES", value: '${CATS_SUITES:-}'


### PR DESCRIPTION
Ref: https://jira.suse.com/browse/CAP-370

Minibroker may need 5 minutes to assemble/deliver its catalog, in slow networks
  * CC must not time out, now given 10 minutes to get the catalog.
  * Brain tests have to be allowed to run longer due this also, now have 20 minutes/test.
    I.e. even when broker goes to the border in delivering the catalog the
    remainder of the test will have its regular 10 minutes to complete.
