### PR TITLE
Fix build cf-ci-orchestration image build

### DIFF
--- a/cf-ci-orchestration/Makefile
+++ b/cf-ci-orchestration/Makefile
@@ -2,7 +2,7 @@ IMAGE ?= splatform/cf-ci-orchestration
 TAG ?= latest
 
 build:
-	docker build -t ${IMAGE}:${TAG} - < Dockerfile
+	docker build -t ${IMAGE}:${TAG} .
 
 push: build
 	docker push ${IMAGE}:${TAG}


### PR DESCRIPTION
If you build using STDIN (docker build - < somefile), there is no build context,
so COPY can’t be used. See:
https://docs.docker.com/engine/reference/builder/