### PR TITLE
Fix usb flag name

### DIFF
--- a/qa-pipelines/qa-pipeline.yml.erb
+++ b/qa-pipelines/qa-pipeline.yml.erb
@@ -11,7 +11,7 @@ def bundle_url_from_version(version)
   end
 end
 
-is_upgrade_pipeline = enable_cf_deploy_pre_upgrade || enable_cf_smoke_tests_pre_upgrade || enable_cf_brain_tests_pre_upgrade || enable_cf_usb_tests
+is_upgrade_pipeline = enable_cf_deploy_pre_upgrade || enable_cf_smoke_tests_pre_upgrade || enable_cf_brain_tests_pre_upgrade || enable_cf_usb_upgrade_tests
 
 %>
 ---


### PR DESCRIPTION
This breaks non-upgrade pipelines due to undefined variable error