### PR TITLE
Add functionality for deploying and preparing a caasp4 cluster

### DIFF
--- a/cap-terraform/caasp4/lbaas-cap.tf
+++ b/cap-terraform/caasp4/lbaas-cap.tf
@@ -1,0 +1,31 @@
+resource "openstack_lb_listener_v2" "uaa_listener" {
+  protocol        = "TCP"
+  protocol_port   = "2793"
+  loadbalancer_id = "${openstack_lb_loadbalancer_v2.lb.id}"
+  name            = "${var.stack_name}-uaa-listener"
+}
+
+resource "openstack_lb_pool_v2" "uaa_pool" {
+  name        = "${var.stack_name}-uaa-pool"
+  protocol    = "TCP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = "${openstack_lb_listener_v2.uaa_listener.id}"
+}
+
+resource "openstack_lb_member_v2" "uaa_member" {
+  count         = "${var.workers}"
+  pool_id       = "${openstack_lb_pool_v2.uaa_pool.id}"
+  address       = "${element(openstack_compute_instance_v2.worker.*.access_ip_v4, count.index)}"
+  subnet_id     = "${openstack_networking_subnet_v2.subnet.id}"
+  protocol_port = 2793
+}
+
+resource "openstack_lb_monitor_v2" "uaa_monitor" {
+  pool_id        = "${openstack_lb_pool_v2.uaa_pool.id}"
+  type           = "TCP"
+  url_path       = "/healthz"
+  expected_codes = 200
+  delay          = 10
+  timeout        = 5
+  max_retries    = 3
+}

--- a/cap-terraform/caasp4/security-groups-cap.tf
+++ b/cap-terraform/caasp4/security-groups-cap.tf
@@ -1,5 +1,5 @@
 resource "openstack_compute_secgroup_v2" "secgroup_cap" {
-  name        = "caasp-cap-${var.stack_name}"
+  name        = "${var.stack_name}-cap_lb_secgroup"
   description = "CAP security group"
 
   rule {

--- a/cap-terraform/caasp4/storage-instance.tf
+++ b/cap-terraform/caasp4/storage-instance.tf
@@ -94,8 +94,8 @@ resource "openstack_compute_instance_v2" "storage" {
   }
 
   security_groups = [
-    "${openstack_compute_secgroup_v2.secgroup_base.name}",
-    "${openstack_compute_secgroup_v2.secgroup_storage.name}",
+    "${openstack_compute_secgroup_v2.storage.name}",
+    "${openstack_networking_secgroup_v2.common.name}",
   ]
 
   user_data = "${data.template_file.storage-cloud-init.rendered}"
@@ -169,7 +169,7 @@ resource "null_resource" "storage_config" {
   }
 }
 
-resource "openstack_compute_secgroup_v2" "secgroup_storage" {
+resource "openstack_compute_secgroup_v2" "storage" {
   name        = "caasp-storage-${var.stack_name}"
   description = "Basic security group"
 

--- a/cap-terraform/caasp4/terraform.tfvars.skel
+++ b/cap-terraform/caasp4/terraform.tfvars.skel
@@ -1,0 +1,99 @@
+# Name of the image to use
+# EXAMPLE:
+# image_name = "SLE-15-SP1-JeOS-GMC"
+# JeOS needs default kernel for the nfs modules
+image_name = "SLE-15-SP1-JeOS-GMC"
+
+# Name of the internal network to be created
+# EXAMPLE:
+# internal_net = "testing"
+internal_net = "#~placeholder_stack~#-net"
+
+# Name of the internal subnet to be created
+# EXAMPLE:
+# internal_subnet = "${var.internal_net}-subnet"
+internal_subnet = "#~placeholder_stack~#-net-subnet"
+
+# Name of the internal router to be created
+# EXAMPLE:
+# internal_router = "${var.internal_net}-router"
+internal_router = "#~placeholder_stack~#-net-router"
+
+# Name of the external network to be used, the one used to allocate floating IPs
+# EXAMPLE:
+# external_net = "floating"
+external_net = "floating"
+
+# Identifier to make all your resources unique and avoid clashes with other users of this terraform project
+stack_name = "#~placeholder_stack~#"
+
+# CIDR of the subnet for the internal network
+# EXAMPLE:
+# subnet_cidr = "172.28.0.0/24"
+subnet_cidr = "172.28.0.0/24"
+
+# Number of master nodes
+masters = 1
+
+# Number of worker nodes
+workers = 3
+
+# Size of the master nodes
+# EXAMPLE:
+# master_size = "m1.medium"
+master_size = "m1.xlarge"
+
+# Size of the worker nodes
+# EXAMPLE:
+# worker_size = "m1.medium"
+worker_size = "m1.xxlarge"
+
+# Attach persistent volumes to workers
+workers_vol_enabled = 0
+
+# Size of the worker volumes in GB
+workers_vol_size = 5
+
+# Name of DNS domain
+# dnsdomain = "my.domain.com"
+dnsdomain = "#~placeholder_stack~#.#~placeholder_magic_dns~#"
+
+# Set DNS Entry (0 is false, 1 is true)
+dnsentry = 0
+
+# define the repositories to use
+# EXAMPLE:
+# repositories = {
+#   repository1 = "http://example.my.repo.com/repository1/"
+#   repository2 = "http://example.my.repo.com/repository2/"
+# }
+repositories = {
+     #~placeholder_caasp_repo~#
+     sle15sp1_pool = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA/standard/"
+     sle15sp1_update = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/"
+     sle15_pool = "http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/"
+     sle15_update = "http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/"
+     suse_ca = "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/"
+}
+
+# Minimum required packages. Do not remove them.
+# Feel free to add more packages
+packages = [
+  "kernel-default",
+  "-kernel-default-base",
+  "ca-certificates-suse",
+  "nfs-client",
+  "#~placeholder_caasp_pattern~#"
+]
+
+# ssh keys to inject into all the nodes
+# EXAMPLE:
+# authorized_keys = [
+#  "ssh-rsa <key-content>"
+# ]
+authorized_keys = [
+"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2G7k0zGAjd+0LzhbPcGLkdJrJ/LbLrFxtXe+LPAkrphizfRxdZpSC7Dvr5Vewrkd/kfYObiDc6v23DHxzcilVC2HGLQUNeUer/YE1mL4lnXC1M3cb4eU+vJ/Gyr9XVOOReDRDBCwouaL7IzgYNCsm0O5v2z/w9ugnRLryUY180/oIGeE/aOI1HRh6YOsIn7R3Rv55y8CYSqsbmlHWiDC6iZICZtvYLYmUmCgPX2Fg2eT+aRbAStUcUERm8h246fs1KxywdHHI/6o3E1NNIPIQ0LdzIn5aWvTCd6D511L4rf/k5zbdw/Gql0AygHBR/wnngB5gSDERLKfigzeIlCKf ./id_shared"
+]
+
+# IMPORTANT: Replace these ntp servers with ones from your infrastructure
+ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]

--- a/cap-terraform/caasp4/terraform.tfvars.skel
+++ b/cap-terraform/caasp4/terraform.tfvars.skel
@@ -92,7 +92,7 @@ packages = [
 #  "ssh-rsa <key-content>"
 # ]
 authorized_keys = [
-"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2G7k0zGAjd+0LzhbPcGLkdJrJ/LbLrFxtXe+LPAkrphizfRxdZpSC7Dvr5Vewrkd/kfYObiDc6v23DHxzcilVC2HGLQUNeUer/YE1mL4lnXC1M3cb4eU+vJ/Gyr9XVOOReDRDBCwouaL7IzgYNCsm0O5v2z/w9ugnRLryUY180/oIGeE/aOI1HRh6YOsIn7R3Rv55y8CYSqsbmlHWiDC6iZICZtvYLYmUmCgPX2Fg2eT+aRbAStUcUERm8h246fs1KxywdHHI/6o3E1NNIPIQ0LdzIn5aWvTCd6D511L4rf/k5zbdw/Gql0AygHBR/wnngB5gSDERLKfigzeIlCKf ./id_shared"
+"#~placeholder_sshkey~#"
 ]
 
 # IMPORTANT: Replace these ntp servers with ones from your infrastructure

--- a/docker/skuba/Dockerfile
+++ b/docker/skuba/Dockerfile
@@ -1,0 +1,15 @@
+FROM registry.opensuse.org/opensuse/leap/15.1/images/totest/containers/opensuse/leap:15.1
+
+ARG VERSION
+ARG REPO_ENV
+ARG REPO
+
+RUN zypper ar --no-gpgcheck "${REPO}" "skuba-${REPO_ENV}" && \
+    zypper ar --no-gpgcheck "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/SUSE:CA.repo" && \
+    zypper ref && \
+    zypper in --auto-agree-with-licenses --no-confirm "skuba-${VERSION}" terraform ca-certificates-suse openssh && \
+    zypper clean -a
+
+VOLUME ["/app"]
+
+WORKDIR /app

--- a/docker/skuba/Makefile
+++ b/docker/skuba/Makefile
@@ -1,0 +1,12 @@
+devel:
+	./build.sh devel http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/
+
+.PHONY: staging
+staging:
+	./build.sh staging http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/staging/
+
+product:
+	./build.sh product http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/
+
+update:
+	./build.sh update http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40:/Update/standard/

--- a/docker/skuba/build.sh
+++ b/docker/skuba/build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+REPO_ENV="$1"
+REPO="$2"
+VERSION=
+
+retrieve_version() {
+  local output=$(docker run --rm -ti registry.suse.com/suse/sle15 sh -c "zypper rr -a && zypper ar -G $REPO skuba-$REPO_ENV > /dev/null 2>&1 && zypper --no-color --no-gpg-checks info -r skuba-$REPO_ENV skuba")
+
+  if [[ $? -eq 0 ]]; then
+    # 0.5.0-1.2 ^M$
+    VERSION="$(echo -n "$output" | grep --color=never "Version" | sed 's/V.*: //' | tr -d ' \t\n\r')"
+
+    echo ">>> INFO: skuba version found, $VERSION"
+    return
+  fi
+
+  if [[ -z $VERSION ]]; then
+    echo ">>> ERROR: no skuba version found" && exit 1
+  fi
+}
+
+build_container() {
+  # local IMAGE_NAME="skuba/$REPO_ENV-$VERSION"
+  local IMAGE_NAME="skuba/$REPO_ENV"
+
+  echo ">>> INFO: Build $IMAGE_NAME"
+  docker build --no-cache -t "$IMAGE_NAME" \
+       --build-arg VERSION="$VERSION" \
+       --build-arg REPO_ENV="$REPO_ENV" \
+       --build-arg REPO="$REPO" .
+}
+
+retrieve_version
+build_container

--- a/qa-manual/caasp4.sh
+++ b/qa-manual/caasp4.sh
@@ -9,6 +9,7 @@ export DEBUG=${DEBUG:-0}
 export KUBECTL_VER="v1.15.2" # TODO not used yet
 export HELM_VER="v2.8.2" # TODO not used yet
 export KUBECONFIG="$WORKSPACE"/kubeconfig
+export MAGIC_DNS_SERVICE='omg.howdoi.website'
 
 # prerrequisites:
 if [[ "$(docker images -q skuba/$CAASP_VER 2> /dev/null)" == "" ]]; then

--- a/qa-manual/caasp4.sh
+++ b/qa-manual/caasp4.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+export CF_CI_DIR=${CF_CI_DIR:-"$(git rev-parse --show-toplevel)"}
+
+export CAASP_VER=${CAASP_VER:-"product"}
+export STACK=${STACK:-"$(whoami)-${CAASP_VER::3}-caasp4-cf-ci"}
+export WORKSPACE=${WORKSPACE:-"$(pwd)/workspace-$STACK"}
+export DEBUG=${DEBUG:-0}
+export KUBECTL_VER="v1.15.2" # TODO not used yet
+export HELM_VER="v2.8.2" # TODO not used yet
+export KUBECONFIG="$WORKSPACE"/kubeconfig
+
+# prerrequisites:
+if [[ "$(docker images -q skuba/$CAASP_VER 2> /dev/null)" == "" ]]; then
+    make -C "$CF_CI_DIR"/docker/skuba/ "$CAASP_VER"
+fi
+if [[ ! -v OS_PASSWORD ]]; then
+    echo ">>> Missing openstack credentials" && exit 1
+fi
+
+# k8s deploy:
+"$CF_CI_DIR"/qa-tools/deploy-caasp4-os.sh
+
+# k8s prepare:
+"$CF_CI_DIR"/qa-tools/prepare-caasp.sh
+
+# TODO cap deploy:
+# "$CF_CI_DIR"/qa-pipelines/tasks/cf-deploy.sh
+
+# TODO cap test:
+# "$CF_CI_DIR"/qa-pipelines/tasks/run-test.sh
+
+# play:
+# cd "$WORKSPACE" && direnv allow
+# kubectl get pods --all-namespaces
+# helm ls
+
+# TODO cap teardown:
+# "$CF_CI_DIR"/qa-tools/cap-teardown.sh
+
+# k8s destroy:
+# cd "$WORKSPACE"/deployment
+# "$CF_CI_DIR"/qa-tools/destroy-caasp4-os.sh

--- a/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
+++ b/qa-pipelines/tasks/lib/cf-deploy-upgrade-common.sh
@@ -277,7 +277,10 @@ set -o allexport
 # The external_ip is set to the internal ip of a worker node. When running on openstack or azure,
 # the public IP (used for DOMAIN) will be taken from the floating IP or load balancer IP.
 
-public_ip="$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"] // ""')"
+if [[ ${cap_platform} == caasp3 || ${cap_platform} == caasp4 || ${cap_platform} == bare ]]; then
+  external_ips=($(kubectl get nodes -o json | jq -r '.items[].status.addresses[] | select(.type == "InternalIP").address'))
+  public_ip=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["public-ip"]')
+fi
 
 if [[ -n "${public_ip}" ]]; then
     # If we have a public IP in the config map, we assume this is openstack / bare metal / etc. and have

--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -233,11 +233,12 @@ fi
 if [[ -f "${test_non_pods_yml}" ]]; then
     kubectl delete --namespace "${CF_NAMESPACE}" --filename "${test_non_pods_yml}"
 fi
-# Delete test pod if they pass. Required pre upgrade
-if [[ $pod_status -eq 0 ]]; then
-    trap "" EXIT
-    kubectl delete pod --namespace=scf ${TEST_NAME}
-else
-    echo "Test failed with status ${pod_status}"
-fi
-exit ${pod_status}
+# TODO
+# # Delete test pod if they pass. Required pre upgrade
+# if [[ $pod_status -eq 0 ]]; then
+#     trap "" EXIT
+#     kubectl delete pod --namespace=scf ${TEST_NAME}
+# else
+#     echo "Test failed with status ${pod_status}"
+# fi
+# exit ${pod_status}

--- a/qa-tools/deploy-caasp4-os.sh
+++ b/qa-tools/deploy-caasp4-os.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploys Caasp4 cluster on openstack, with an nfs server, and prepares
+# it for CAP.
+#
+# Requires:
+# - Built skuba docker image
+# - Sourced openrc.sh
+# - Key on the ssh keyring. If not, will put one
+
+SKUBA_DEPLOY_PATH="$CF_CI_DIR"/qa-tools/skuba-deploy.sh
+skuba-deploy() {
+    bash "$SKUBA_DEPLOY_PATH" "$@"
+}
+
+if [[ -d "$WORKSPACE" ]]; then
+    echo ">>> Aborting: WORKSPACE=$WORKSPACE already exists, you have an existing deployment"
+    exit 1
+else
+    mkdir -p "$WORKSPACE"
+fi
+
+# check ssh key
+agent="$(pgrep ssh-agent -u "$USER")"
+if [[ "$agent" == "" ]]; then
+    eval "$(ssh-agent -s)"
+fi
+if ! ssh-add -L | grep -q 'ssh' ; then
+    echo ">>> Adding ssh key"
+    curl "https://raw.githubusercontent.com/SUSE/skuba/master/ci/infra/id_shared" -o "$WORKSPACE"/id_rsa \
+        && chmod 0600 "$WORKSPACE"/id_rsa
+    ssh-add "$WORKSPACE"/id_rsa
+fi
+
+if [[ ! -v OS_PASSWORD ]]; then
+    echo ">>> Missing openstack credentials" && exit 1
+fi
+
+echo ">>> Extracting terraform files from skuba package"
+docker run \
+       --name skuba-"$CAASP_VER" \
+       --detach \
+       --rm \
+       skuba/"$CAASP_VER" sleep infinity
+docker cp \
+       skuba-"$CAASP_VER":/usr/share/caasp/terraform/openstack/. \
+       "$WORKSPACE"/deployment
+docker rm -f skuba-"$CAASP_VER"
+
+echo ">>> Copying our own terraform files"
+case "$CAASP_VER" in
+    "devel")
+         CAASP_REPO='caasp_40_devel_sle15sp1 = "http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/"'
+         ;;
+    "staging")
+         CAASP_REPO='caasp_40_staging_sle15sp1 = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/staging/"'
+         ;;
+    "product")
+         CAASP_REPO='caasp_40_product_sle15sp1 = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/"'
+         ;;
+    "update")
+         CAASP_REPO='caasp_40_update_sle15sp1 = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40:/Update/standard/"'
+         ;;
+esac
+echo ">>>>>> Using $CAASP_REPO"
+escapeSubst() {
+    # escape string for usage in a sed substitution expression
+    IFS= read -d '' -r < <(sed -e ':a' -e '$!{N;ba' -e '}' -e 's%[&/\]%\\&%g; s%\n%\\&%g' <<<"$1")
+    printf %s "${REPLY%$'\n'}"
+}
+SSHKEY="$(ssh-add -L)"
+if [[ ! -v MAGIC_DNS_SERVICE ]]; then
+    MAGIC_DNS_SERVICE='omg.howdoi.website'
+fi
+CAASP_PATTERN='patterns-caasp-Node-1.15'
+sed -e "s%#~placeholder_stack~#%$(escapeSubst "$STACK")%g" \
+    -e "s%#~placeholder_magic_dns~#%$(escapeSubst "$MAGIC_DNS_SERVICE")%g" \
+    -e "s%#~placeholder_caasp_repo~#%$(escapeSubst "$CAASP_REPO")%g" \
+    -e "s%#~placeholder_sshkey~#%$(escapeSubst "$SSHKEY")%g" \
+    -e "s%#~placeholder_caasp_pattern~#%$(escapeSubst "$CAASP_PATTERN")%g" \
+    "$(dirname "$0")/../cap-terraform/caasp4/terraform.tfvars.skel" > \
+    "$WORKSPACE"/deployment/terraform.tfvars
+sed -i '/\"\${openstack_compute_secgroup_v2\.secgroup_worker\.name}\",/a \ \ \ \ "\${openstack_compute_secgroup_v2.secgroup_cap.name}",' "$WORKSPACE"/deployment/worker-instance.tf
+
+cp -r "$(dirname "$0")/../cap-terraform/caasp4"/* "$WORKSPACE"/deployment/
+
+pushd "$WORKSPACE"/deployment
+cd ~0
+
+echo ">>> Deploying with terraform"
+skuba-deploy --run-in-docker terraform init
+skuba-deploy --run-in-docker terraform plan -out my-plan
+skuba-deploy --run-in-docker terraform apply -auto-approve my-plan
+
+echo ">>> Bootstrapping cluster with skuba"
+export KUBECONFIG=
+skuba-deploy --deploy
+wait
+cp "$WORKSPACE"/deployment/my-cluster/admin.conf "$WORKSPACE/kubeconfig"
+export KUBECONFIG="$WORKSPACE"/kubeconfig
+cp "$CF_CI_DIR"/qa-tools/misc/envrc "$WORKSPACE"/.envrc
+echo ">>> Deployment at $WORKSPACE/deployment/"
+
+echo ">>> Disabling automatic updates in cluster"
+skuba-deploy --updates all disable
+wait
+
+echo ">>> Disabling automatic reboots in cluster"
+skuba-deploy --reboots disable
+wait
+
+echo ">>> Enabling swapaccount on all nodes"
+skuba-deploy --run-cmd all "sudo sed -i -r 's|^(GRUB_CMDLINE_LINUX_DEFAULT=)\"(.*.)\"|\1\"\2 cgroup_enable=memory swapaccount=1 \"|' /etc/default/grub"
+wait
+skuba-deploy --run-cmd all 'sudo grub2-mkconfig -o /boot/grub2/grub.cfg'
+wait
+skuba-deploy --run-cmd all 'sleep 2 && sudo nohup shutdown -r now > /dev/null 2>&1 &'
+wait
+
+echo ">>> Waiting for nodes to be up"
+skuba-deploy --wait-ssh all 100
+
+# Create configmap:
+PUBLIC_IP="$(skuba-deploy --run-in-docker terraform output ip_workers | cut -d, -f1 | head -n1)"
+export PUBLIC_IP
+# openstack images rootfs:
+ROOTFS=overlay-xfs
+export ROOTFS
+NFS_SERVER_IP="$(skuba-deploy --run-in-docker terraform output ip_storage_int)"
+export NFS_SERVER_IP
+NFS_PATH="$(skuba-deploy --run-in-docker terraform output storage_share)"
+export NFS_PATH
+
+if kubectl get configmap -n kube-system 2>/dev/null | grep -qi cap-values; then
+    echo ">>> Skipping creating configmap cap-values; already exists"
+else
+    echo ">>> Creating configmap cap-values"
+    kubectl create configmap -n kube-system cap-values \
+            --from-literal=public-ip="${PUBLIC_IP}" \
+            --from-literal=garden-rootfs-driver="${ROOTFS}" \
+            --from-literal=nfs-server-ip="${NFS_SERVER_IP}" \
+            --from-literal=nfs-path="${NFS_PATH}" \
+            --from-literal=platform=caasp4
+fi
+
+echo ">>> Deployed caasp4 on openstack. kubeconfig at $WORKSPACE/kubeconfig"

--- a/qa-tools/deploy-caasp4-os.sh
+++ b/qa-tools/deploy-caasp4-os.sh
@@ -119,7 +119,8 @@ skuba-deploy --run-cmd all 'sleep 2 && sudo nohup shutdown -r now > /dev/null 2>
 wait
 
 echo ">>> Waiting for nodes to be up"
-skuba-deploy --wait-ssh all 100
+# skuba-deploy --wait-ssh all 100
+sleep 100
 
 # Create configmap:
 PUBLIC_IP="$(skuba-deploy --run-in-docker terraform output ip_workers | cut -d, -f1 | head -n1)"

--- a/qa-tools/deploy-caasp4-os.sh
+++ b/qa-tools/deploy-caasp4-os.sh
@@ -70,9 +70,6 @@ escapeSubst() {
     printf %s "${REPLY%$'\n'}"
 }
 SSHKEY="$(ssh-add -L)"
-if [[ ! -v MAGIC_DNS_SERVICE ]]; then
-    MAGIC_DNS_SERVICE='omg.howdoi.website'
-fi
 CAASP_PATTERN='patterns-caasp-Node-1.15'
 sed -e "s%#~placeholder_stack~#%$(escapeSubst "$STACK")%g" \
     -e "s%#~placeholder_magic_dns~#%$(escapeSubst "$MAGIC_DNS_SERVICE")%g" \

--- a/qa-tools/deploy-caasp4-os.sh
+++ b/qa-tools/deploy-caasp4-os.sh
@@ -78,7 +78,8 @@ sed -e "s%#~placeholder_stack~#%$(escapeSubst "$STACK")%g" \
     -e "s%#~placeholder_caasp_pattern~#%$(escapeSubst "$CAASP_PATTERN")%g" \
     "$(dirname "$0")/../cap-terraform/caasp4/terraform.tfvars.skel" > \
     "$WORKSPACE"/deployment/terraform.tfvars
-sed -i '/\"\${openstack_compute_secgroup_v2\.secgroup_worker\.name}\",/a \ \ \ \ "\${openstack_compute_secgroup_v2.secgroup_cap.name}",' "$WORKSPACE"/deployment/worker-instance.tf
+sed -i '/\"\${openstack_networking_secgroup_v2\.secgroup.common\.name}\",/a \ \ \ \ "\${openstack_compute_secgroup_v2.secgroup_cap.name}",' \
+    "$WORKSPACE"/deployment/worker-instance.tf
 
 cp -r "$(dirname "$0")/../cap-terraform/caasp4"/* "$WORKSPACE"/deployment/
 

--- a/qa-tools/destroy-caasp4-os.sh
+++ b/qa-tools/destroy-caasp4-os.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Destroys an existing Caasp4 cluster on openstack
+#
+# Requirements:
+# - Built skuba docker image
+# - Sourced openrc.sh
+# - Key on the ssh keyring
+
+SKUBA_DEPLOY_PATH="$CF_CI_DIR"/qa-tools/skuba-deploy.sh
+skuba-deploy() {
+    bash "$SKUBA_DEPLOY_PATH" "$@"
+}
+
+KUBECONFIG="$WORKSPACE"/kubeconfig
+
+if [[ ! -v OS_PASSWORD ]]; then
+    echo ">>> Missing openstack credentials" && exit 1
+fi
+
+if [[ -f "$KUBECONFIG" ]] &&  kubectl get storageclass 2>/dev/null | grep -qi persistent; then
+    echo ">>> Destroying storageclass"
+    # allows the nfs server to delete the share
+    kubectl delete storageclass persistent
+    wait
+fi
+
+echo ">>> Destroying deployed openstack stack"
+cd "$WORKSPACE"/deployment
+skuba-deploy --run-in-docker terraform destroy -auto-approve
+echo ">>> Destroyed openstack stack"

--- a/qa-tools/destroy-caasp4-os.sh
+++ b/qa-tools/destroy-caasp4-os.sh
@@ -13,7 +13,7 @@ skuba-deploy() {
     bash "$SKUBA_DEPLOY_PATH" "$@"
 }
 
-KUBECONFIG="$WORKSPACE"/kubeconfig
+export KUBECONFIG="$WORKSPACE"/kubeconfig
 
 if [[ ! -v OS_PASSWORD ]]; then
     echo ">>> Missing openstack credentials" && exit 1

--- a/qa-tools/misc/envrc
+++ b/qa-tools/misc/envrc
@@ -1,0 +1,3 @@
+export KUBECONFIG=$(pwd)/kubeconfig
+export HELM_HOME=$(pwd)/.helm
+export CF_HOME=$(pwd)/.cf

--- a/qa-tools/prepare-caasp.sh
+++ b/qa-tools/prepare-caasp.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+# Takes a newly deployed Caasp4 cluster, provided by the kubeconfig, and prepares
+# it for CAP
+#
+# Requires:
+# kubectl & helm binaries
+
+
+create_rolebinding() {
+    echo ">>> Applying cluster admin RBACs"
+    kubectl apply -f - < "$(dirname $0)"/cluster-admin.yaml
+}
+
+install_helm_and_tiller() {
+    export HELM_HOME="$WORKSPACE"/.helm
+    # install helm & tiller
+    if kubectl get pods --all-namespaces 2>/dev/null | grep -qi tiller; then
+        echo ">>> Installing helm client"
+         helm init --client-only
+    else
+        echo ">>> Installing helm client and tiller"
+        kubectl create serviceaccount tiller --namespace kube-system
+        helm init --wait
+    fi
+    echo ">>> Installed helm successfully"
+}
+
+create_nfs_storageclass() {
+    # Create nfs storageclass with provided nfs server
+    if kubectl get storageclass 2>/dev/null | grep -qi persistent; then
+        echo ">>> Skipping setting up storageclass \"persistent\"; already exists"
+    else
+        echo ">>> Creating storage class with provided nfs server"
+        NFS_SERVER_IP=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["nfs-server-ip"]')
+        NFS_PATH=$(kubectl get configmap -n kube-system cap-values -o json | jq -r '.data["nfs-path"]')
+        helm install stable/nfs-client-provisioner --set nfs.server="$NFS_SERVER_IP" --set nfs.path="$NFS_PATH" \
+             --set storageClass.name=persistent \
+             --set storageClass.reclaimPolicy=Delete --set storageClass.archiveOnDelete=false
+    fi
+}
+
+create_qa_sa_config() {
+    echo ">>> Creating qa config"
+    export WORKSPACE
+    "$(dirname $0)"/create-qa-config.sh >/dev/null 2>&1
+}
+
+echo ">>> Preparing cluster for CAP"
+create_rolebinding
+install_helm_and_tiller
+create_nfs_storageclass
+create_qa_sa_config
+echo ">>> Done preparing cluster for CAP"

--- a/qa-tools/skuba-deploy.sh
+++ b/qa-tools/skuba-deploy.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -v DEBUG ]]; then
+    export DEBUG=0
+fi
+CLUSTER_NAME="my-cluster"
+
+USAGE=$(cat <<USAGE
+Usage:
+
+--deploy
+
+--updates <target> <action>
+    --updates all disable
+
+--reboots <target> <action>
+    --reboots all disable
+
+--node-upgrade <target>
+    --node-upgrade all
+    --node-upgrade masters
+    --node-upgrade workers
+
+--show-images
+
+--run-cmd <target> "sudo ..."
+
+--run-in-docker <docker_binary>
+
+--scp <target> <src_files> <dest_files>
+USAGE
+)
+
+skuba_container() {
+  local app_path="$PWD"
+  if [[ "$1" == "$CLUSTER_NAME" ]]; then
+      local app_path="$PWD/$1"
+      shift
+  fi
+
+  docker run -i --rm \
+  -v "$app_path":/app:rw \
+  -v "$(dirname "$SSH_AUTH_SOCK")":"$(dirname "$SSH_AUTH_SOCK")" \
+  -v "/etc/passwd:/etc/passwd:ro" \
+  --env-file <( env| cut -f1 -d= ) \
+  -e SSH_AUTH_SOCK="$SSH_AUTH_SOCK" \
+  -u "$(id -u)":"$(id -g)" \
+  skuba/$CAASP_VER "$@"
+}
+
+ssh2() {
+  local host=$1
+  shift
+  ssh -o UserKnownHostsFile=/dev/null \
+      -o StrictHostKeyChecking=no \
+      -F /dev/null \
+      -o LogLevel=ERROR \
+      "sles@$host" "$@"
+}
+
+wait_ssh() {
+    timeout=$2
+    define_node_group "$1"
+    for n in $GROUP; do
+        secs=0
+        set +e
+        ssh2 $n exit
+        while test $? -gt 0
+        do
+            if [ $secs -gt $timeout ] ; then
+                echo ">>> Timeout while waiting for $n"
+                exit 2
+            else
+                sleep 5
+                secs=$(( secs + 5 ))
+                ssh2 $n exit
+            fi
+        done
+        set -e
+    done
+}
+
+reboots() {
+#kubectl -n kube-system patch ds kured -p '{"spec":{"template":{"metadata":{"labels":{"name":"kured"}},"spec":{"containers":[{"name":"kured","command":["/usr/bin/kured", "--period=10s"]}]}}}}'
+  local action="$1"
+  if [[ "$action" == "disable" ]]; then
+    kubectl -n kube-system annotate ds kured weave.works/kured-node-lock='{"nodeID":"manual"}'
+  else
+    kubectl -n kube-system annotate ds kured weave.works/kured-node-lock-
+  fi
+}
+
+run_cmd() {
+  define_node_group "$1"
+  CMD="$2"
+  for n in $GROUP; do
+      echo ">>> Running '$CMD' on $n"
+      ssh2 "$n" "$CMD"
+  done
+}
+
+use_scp() {
+  define_node_group "$1"
+  SRC="$2"
+  DEST="$3"
+  local options="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -F /dev/null -o LogLevel=ERROR -r"
+
+  for n in $GROUP; do
+      echo ">>> SCP '$SRC' to '$DEST' on $n"
+      scp "$options" "$SRC" sles@$n:"$DEST"
+  done
+}
+
+show_images() {
+  kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec.containers[*].image}" | tr -s '[[:space:]]' '\n'
+}
+
+updates() {
+  define_node_group "$1"
+  local action="$2"
+  for n in $GROUP; do
+      echo ">>> $action skuba-update on $n"
+      ssh2 "$n" "sudo systemctl $action --now skuba-update.timer"
+  done
+}
+
+init_control_plane() {
+  if ! [[ -d "$CLUSTER_NAME" ]]; then
+      echo ">>> Deploying control plane"
+      skuba_container skuba cluster init --control-plane "$LB" "$CLUSTER_NAME"
+  fi
+}
+
+deploy_masters() {
+local i=0
+for n in $1; do
+    local j="$(printf "%03g" $i)"
+    if [[ $i -eq 0 ]]; then
+      echo ">>> Boostrapping first master node, master$j: $n"
+      skuba_container "$CLUSTER_NAME" skuba node bootstrap --user sles --sudo --target "$n" "master$j" -v "$DEBUG"
+      wait
+    fi
+
+    if [[ $i -ne 0 ]]; then
+      echo ">>> Boostrapping other master nodes, master$j: $n"
+      skuba_container "$CLUSTER_NAME" skuba node join --role master --user sles --sudo --target  "$n" "master$j" -v "$DEBUG"
+      wait
+    fi
+    ((++i))
+done
+}
+
+deploy_workers() {
+  local i=0
+  for n in $1; do
+      local j="$(printf "%03g" $i)"
+      echo ">>> Deploying workers, worker$j: $n"
+      (skuba_container "$CLUSTER_NAME" skuba node join --role worker --user sles --sudo --target  "$n" "worker$j" -v "$DEBUG") &
+      wait
+      ((++i))
+  done
+}
+
+deploy() {
+  init_control_plane
+  pushd $(pwd)/
+  deploy_masters "$MASTERS"
+  deploy_workers "$WORKERS"
+  echo ">>> Cluster bootstraped:"
+  skuba_container $CLUSTER_NAME skuba cluster status
+}
+
+set_env_vars() {
+    JSON=$(skuba_container terraform output -json)
+    export LB=$(echo "$JSON" | jq -r '.ip_load_balancer.value')
+    export MASTERS=$(echo "$JSON" | jq -r '.ip_masters.value[]')
+    export WORKERS=$(echo "$JSON" | jq -r '.ip_workers.value[]')
+    export ALL="$MASTERS $WORKERS"
+}
+
+define_node_group() {
+  set_env_vars
+  case "$1" in
+    "all")
+    GROUP="$ALL"
+    ;;
+    "masters")
+    GROUP="$MASTERS"
+    ;;
+    "workers")
+    GROUP="$WORKERS"
+    ;;
+    *)
+    GROUP="$1"
+    ;;
+  esac
+}
+
+node_upgrade() {
+  define_node_group "$1"
+
+  local i=0
+  for n in $GROUP; do
+  #    local j="$(printf "%03g" $i)"
+      echo ">>> Upgrading node $n"
+
+  #    skuba "$CLUSTER_NAME" node upgrade plan  -v "$DEBUG"
+      skuba_container "$CLUSTER_NAME" skuba node upgrade apply --user sles --sudo --target "$n" -v "$DEBUG"
+  #  ((++i))
+  done
+}
+
+# Parse options
+while [[ $# -gt 0 ]] ; do
+    case $1 in
+    --deploy)
+      set_env_vars
+      deploy
+      ;;
+    --run-in-docker)
+      shift
+      skuba_container "$@"
+      ;;
+    --node-upgrade)
+      node_upgrade "$TARGET"
+      ;;
+    --updates)
+      TARGET="${2:-all}"
+      ACTION="${3:-disable}"
+      updates "$TARGET" "$ACTION"
+      ;;
+    --reboots)
+      ACTION="${2:-disable}"
+      reboots "$ACTION"
+      ;;
+    --run-cmd)
+      TARGET="${2:-all}"
+      CMD="$3"
+      run_cmd "$TARGET" "$CMD"
+      ;;
+    --wait-ssh)
+      TARGET="${2:-all}"
+      TIMEOUT="${3:-30}"
+      wait_ssh "$TARGET" "$TIMEOUT"
+      ;;
+    --scp)
+      TARGET="${2:-all}"
+      SRC="$3"
+      DEST="$4"
+      use_scp "$TARGET" "$SRC" "$DEST"
+      ;;
+    --show-images)
+      show_images
+      ;;
+    -h|--help)
+      echo "$USAGE"
+      exit 0
+      ;;
+    esac
+    shift
+done


### PR DESCRIPTION
This PR adds:

- dockerfiles/skuba/ for creating skuba docker images to run commands from
- qa-tools/skuba-deploy.sh for deploying and interacting with caasp4 cluster using a
    skuba docker image
- A skeleton of terraform.tfvars for caasp4 usage
- qa-tools/deploy-caasp4-openstack.sh for deploying and preparing caasp clusters, using
    the above
- qa-tools/prepare-caasp.sh for preparing a caasp cluster for a cap deployment
- qa-manual/caasp4.sh to deploy and prepare caasp4 deployments from a local machine
