### PR TITLE
Add options to test HA_strict

### DIFF
--- a/qa-pipelines/config.yml
+++ b/qa-pipelines/config.yml
@@ -22,7 +22,7 @@ magic-dns-service: omg.howdoi.website
 
 src-repo: SUSE/scf
 
-cap-pre-upgrade-url: master/scf-sle-2.17.1%2Bcf7.11.0.4.ga6c993eb 
+cap-pre-upgrade-url: master/scf-sle-2.17.1%2Bcf7.11.0.4.ga6c993eb
 cap-install-url: null
 
 status-email-host: *ci-status-email-host
@@ -37,3 +37,10 @@ status-email-receiver: *ci-status-email-receiver
 enable-embedded-uaa: false
 enable-autoscaler: true
 enable-credhub: true
+# The following two options test that ha strict mode works by adjusting the diego_api count to 1
+# This will only have an effect on builds from the HA job. When testing, only one of these flags should be set to true
+# For non-upgrade pipelines, this affects cf-deploy, and for upgrade pipelines, it affects the upgrade step
+# test-ha-strict-enable leaves the default HA_strict setting (true), and sets diego_api count to 1
+test-ha-strict-enable: false
+# test-ha-strict-enable sets HA_strict to false, and sets diego_api count to 1
+test-ha-strict-disable: false

--- a/qa-pipelines/qa-pipeline.yml.erb
+++ b/qa-pipelines/qa-pipeline.yml.erb
@@ -54,6 +54,9 @@ aliases:
     <% else %>
     KLOG_COLLECTION_ON_FAILURE: false
     <% end %> # klog_collection_on_failure
+    <% if test_ha_strict_enable || test_ha_strict_disable %>
+    HA_STRICT: <%= test_ha_strict_enable %>
+    <% end %> # test_ha_strict_enable || test_ha_strict_disable %>
   upgrade-task-params: &upgrade-task-params
     << : *common-task-params
     CAP_BUNDLE_URL: <%= bundle_url_from_version("#{s3_config_bucket_sles}.s3.amazonaws.com", cap_pre_upgrade_url || enable_cf_deploy_pre_upgrade) %>

--- a/qa-pipelines/tasks/cf-deploy.sh
+++ b/qa-pipelines/tasks/cf-deploy.sh
@@ -61,9 +61,6 @@ fi
 set_helm_params # Resets HELM_PARAMS
 set_scf_sizing_params # Adds scf sizing params to HELM_PARAMS
 
-echo SCF customization ...
-echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
-
 kubectl create namespace "${CF_NAMESPACE}"
 if [[ ${PROVISIONER} == kubernetes.io/rbd ]]; then
     kubectl get secret -o yaml ceph-secret-admin | sed "s/namespace: default/namespace: ${CF_NAMESPACE}/g" | kubectl create -f -
@@ -72,6 +69,15 @@ fi
 if [[ "${EMBEDDED_UAA:-false}" != "true" ]]; then
     HELM_PARAMS+=(--set "secrets.UAA_CA_CERT=$(get_uaa_ca_cert)")
 fi
+
+# When this deploy task is running in a deploy (non-upgrade) pipeline, the deploy is HA, and we want to test config.HA_strict:
+if [[ "${HA}" == true ]] && [[ -n "${HA_STRICT:-}" ]] && [[ -z "${CAP_BUNDLE_URL:-}" ]]; then
+    HELM_PARAMS+=(--set "config.HA_strict=${HA_STRICT}")
+    HELM_PARAMS+=(--set "sizing.diego_api.count=1")
+fi
+
+echo SCF customization ...
+echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
 
 helm install ${CAP_DIRECTORY}/helm/cf/ \
     --namespace "${CF_NAMESPACE}" \

--- a/qa-pipelines/tasks/cf-deploy.yml
+++ b/qa-pipelines/tasks/cf-deploy.yml
@@ -32,6 +32,7 @@ params:
   EMBEDDED_UAA: false # true or false
   ENABLE_CREDHUB: true
   ENABLE_AUTOSCALER: true
+  HA_STRICT: "" # set to true or false when testing HA_strict
 
 run:
   path: ci/qa-pipelines/tasks/cf-deploy.sh

--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -70,12 +70,18 @@ fi
 set_helm_params # Resets HELM_PARAMS
 set_scf_sizing_params # Adds scf sizing params to HELM_PARAMS
 
-echo SCF customization ...
-echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
-
 if [[ "${EMBEDDED_UAA:-false}" != "true" ]]; then
     HELM_PARAMS+=(--set "secrets.UAA_CA_CERT=$(get_uaa_ca_cert)")
 fi
+
+# When this upgrade task is running in an HA job, and we want to test config.HA_strict:
+if [[ "${HA}" == true ]] && [[ -n "${HA_STRICT:-}" ]]; then
+    HELM_PARAMS+=(--set "config.HA_strict=${HA_STRICT}")
+    HELM_PARAMS+=(--set "sizing.diego_api.count=1")
+fi
+
+echo SCF customization ...
+echo "${HELM_PARAMS[@]}" | sed 's/kube\.registry\.password=[^[:space:]]*/kube.registry.password=<REDACTED>/g'
 
 helm upgrade scf ${CAP_DIRECTORY}/helm/cf/ \
     --namespace "${CF_NAMESPACE}" \

--- a/qa-pipelines/tasks/cf-upgrade.yml
+++ b/qa-pipelines/tasks/cf-upgrade.yml
@@ -30,6 +30,7 @@ params:
   EMBEDDED_UAA: false # true or false
   ENABLE_CREDHUB: true
   ENABLE_AUTOSCALER: true
+  HA_STRICT: "" # set to true or false when testing HA_strict
 
 run:
   path: ci/qa-pipelines/tasks/cf-upgrade.sh


### PR DESCRIPTION
This branch is based on top of #268 and #292 (required for testing) and should not be merged before those.

Allow testing of HA_strict setting. This adds two new pipeline config
settings:
- test-ha-strict-enable
- test-ha-strict-disable
When testing the HA_strict setting, helm deploy/upgrade will occur with
HA_strict enabled or disabled, depending on which one of these is set to
true.
For upgrade pipelines, the diego_api count will only be set to 1 on the
upgrade step.
These flags don't affect builds from the SA job.