### PR TITLE
Use kubectl apply for brains resource definitions

### DIFF
--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -141,7 +141,7 @@ if [[ ${TEST_NAME} == "acceptance-tests-brain" ]]; then
         end
 EOF
     if [[ -f "${test_non_pods_yml}" ]]; then
-        kubectl create --namespace "${CF_NAMESPACE}" --filename "${test_non_pods_yml}"
+        kubectl apply --namespace "${CF_NAMESPACE}" --filename "${test_non_pods_yml}"
     fi
 fi
 


### PR DESCRIPTION
If reusing a cluster where the brains tests previously failed,
supporting resources for the brains pod which are not namespaced may
still exist, causing failures with kubectl create. We should prefer
kubectl apply as it will exit without failure when resources already
exist, and update them accordingly when they're leftover from a previous
version's brains