### PR TITLE
Disable autoscaler in default config

### DIFF
--- a/qa-pipelines/config.yml
+++ b/qa-pipelines/config.yml
@@ -35,7 +35,7 @@ status-email-receiver: *ci-status-email-receiver
 # When deploying / upgrading, use the embedded UAA instead of the normal,
 # separately namespaced UAA.
 enable-embedded-uaa: false
-enable-autoscaler: true
+enable-autoscaler: false
 enable-credhub: true
 # The following two options test that ha strict mode works by adjusting the diego_api count to 1
 # This will only have an effect on builds from the HA job. When testing, only one of these flags should be set to true


### PR DESCRIPTION
This is in response to a race condition which requires the user to
manually run a workaround script when encountered. See
https://github.com/SUSE/scf/pull/2680 for more information