### PR TITLE
Adding SCF v3 build pipelines

### DIFF
--- a/build-pipelines/generate-pipeline.rb
+++ b/build-pipelines/generate-pipeline.rb
@@ -34,4 +34,4 @@ class PipelineDeployer
     end
 end
 
-PipelineDeployer.new.render *ARGV.first(6)
+PipelineDeployer.new.render *ARGV.first(3)

--- a/build-pipelines/generate-pipeline.rb
+++ b/build-pipelines/generate-pipeline.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+require 'erb'
+require 'optparse'
+require 'ostruct'
+require 'yaml'
+
+class PipelineDeployer
+    # fix_key converts the key into something that can be a ruby variable name
+    def fix_key(k)
+        k.tr('-', '_').to_sym
+    end
+
+    def eval_context(config_file, secrets_file)
+        # Load the configuration file
+        @eval_context ||= binding.dup.tap do |context|
+            vars_file="---\n"
+            [secrets_file, config_file].each do |file|
+                vars_file += File.read(file).split("\n").select{ |line| line !~ /^---$/ }.join("\n") + "\n"
+            end
+            YAML.load(vars_file).each do |k, v|
+                context.local_variable_set fix_key(k), v
+            end
+        end
+    end
+
+    def render(template_file, config_file, secrets_file)
+        # Render the template
+        filename = File.join(__dir__, template_file)
+        template = ERB.new(File.read(filename))
+        template.filename = filename
+        result = YAML.load template.result(eval_context(config_file, secrets_file))
+        puts result.to_yaml
+    end
+end
+
+PipelineDeployer.new.render *ARGV.first(6)

--- a/build-pipelines/release-images-cf-deployment/config.yml
+++ b/build-pipelines/release-images-cf-deployment/config.yml
@@ -1,0 +1,23 @@
+cf-deployment-tags:
+  - v8.0.0
+  - v9.2.0
+  - v9.5.0
+ci-repo: https://github.com/suse/cf-ci
+ci-branch: bisingh/cf-operator-ci
+docker-image-resource-repo: https://github.com/concourse/docker-image-resource
+docker-image-resource-branch: master
+cf-deployment-repo: https://github.com/cloudfoundry/cf-deployment
+cf-deployment-branch: master
+cf-deployment-yaml: cf-deployment/cf-deployment.yml
+fissile-linux-s3-bucket: cf-opensusefs2
+stemcell-os: SLE
+stemcell-repository: *docker-internal-fissile-image
+stemcell-versions-s3-bucket: suse-bosh-sles-stemcells
+stemcell-version-file: VERSION.txt
+stemcell-s3-bucket-region: eu-central-1
+docker-registry: *docker-internal-registry
+docker-organization: *docker-org
+docker-username: *docker-internal-username
+docker-password: *docker-internal-password
+s3-access-key: *aws-capbot-access-key
+s3-secret-key: *aws-capbot-secret-key

--- a/build-pipelines/release-images-cf-deployment/pipeline.yml.erb
+++ b/build-pipelines/release-images-cf-deployment/pipeline.yml.erb
@@ -1,0 +1,65 @@
+# This pipeline will setup the build for all the cf_deployment_releases specified below.
+
+resources:
+- name: ci
+  type: git
+  source:
+    uri: <%= ci_repo %>
+    branch: <%= ci_branch %>
+- name: docker-image-resource
+  type: git
+  source:
+    uri: <%= docker_image_resource_repo %>
+    branch: <%= docker_image_resource_branch %>
+<% cf_deployment_tags.each do |cf_deployment_tag| %>
+- name: cf-deployment-<%= cf_deployment_tag %>
+  type: git
+  source:
+    uri: <%= cf_deployment_repo %>
+    branch: <%= cf_deployment_branch %>
+    tag_filter: <%= cf_deployment_tag %>
+<% end %>
+- name: s3.fissile-linux
+  type: s3
+  source:
+    bucket: <%= fissile_linux_s3_bucket %>
+    private: true
+    regexp: fissile/develop/fissile-(.*)\.tgz
+- name: s3.fissile-stemcell-version
+  type: s3
+  source:
+    bucket: <%= stemcell_versions_s3_bucket %>
+    region_name: <%= stemcell_s3_bucket_region %>
+    access_key_id: <%= s3_access_key %>
+    secret_access_key: <%= s3_secret_key %>
+    versioned_file: <%= stemcell_version_file %>
+    
+jobs:
+<% cf_deployment_tags.each do |cf_deployment_tag| %>
+- name: build-<%= cf_deployment_tag %>
+  plan:
+  - in_parallel:
+    - get: ci
+    - get: docker-image-resource
+    - get: cf-deployment-<%= cf_deployment_tag %>
+    - get: s3.fissile-stemcell-version
+      trigger: true
+    - get: s3.fissile-linux
+      trigger: true
+  - do:
+    - task: build
+      privileged: true
+      input_mapping:
+        s3.stemcell-version: s3.fissile-stemcell-version
+        cf-deployment: cf-deployment-<%= cf_deployment_tag %>
+      params:
+        STEMCELL_OS: <%= stemcell_os %>
+        STEMCELL_REPOSITORY: <%= stemcell_repository %>
+        STEMCELL_VERSIONED_FILE: <%= stemcell_version_file %>
+        CF_DEPLOYMENT_YAML: <%= cf_deployment_yaml %>
+        DOCKER_REGISTRY: <%= docker_registry %>
+        DOCKER_ORGANIZATION: <%= docker_organization %>
+        DOCKER_TEAM_USERNAME: <%= docker_username %>
+        DOCKER_TEAM_PASSWORD_RW: <%= docker_password %>
+      file: ci/build-pipelines/release-images-cf-deployment/tasks/build.yml
+<% end %>

--- a/build-pipelines/release-images-cf-deployment/tasks/build.sh
+++ b/build-pipelines/release-images-cf-deployment/tasks/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+# Start the Docker daemon.
+source docker-image-resource/assets/common.sh
+max_concurrent_downloads=10
+max_concurrent_uploads=10
+insecure_registries=""
+registry_mirror=""
+start_docker \
+  "${max_concurrent_downloads}" \
+  "${max_concurrent_uploads}" \
+  "${insecure_registries}" \
+  "${registry_mirror}"
+trap 'stop_docker' EXIT
+
+# Login to the Docker registry.
+echo "${DOCKER_TEAM_PASSWORD_RW}" | docker login "${DOCKER_REGISTRY}" --username "${DOCKER_TEAM_USERNAME}" --password-stdin
+
+# Extract the fissile binary.
+tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
+
+# Pull the stemcell image.
+stemcell_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}")"
+stemcell_image="${STEMCELL_REPOSITORY}:${stemcell_version}"
+docker pull "${stemcell_image}"
+
+# Build the releases.
+tasks_dir="$(dirname $0)"
+bash <(yq -r ".manifest_version as \$cf_version | .releases[] | \"source ${tasks_dir}/build_release.sh; build_release \\(\$cf_version|@sh) '${DOCKER_REGISTRY}' '${DOCKER_ORGANIZATION}' '${DOCKER_TEAM_USERNAME}' '${DOCKER_TEAM_PASSWORD_RW}' '${STEMCELL_OS}' '${stemcell_version}' '${stemcell_image}' \\(.name|@sh) \\(.url|@sh) \\(.version|@sh) \\(.sha1|@sh)\"" "${CF_DEPLOYMENT_YAML}")

--- a/build-pipelines/release-images-cf-deployment/tasks/build.yml
+++ b/build-pipelines/release-images-cf-deployment/tasks/build.yml
@@ -1,0 +1,22 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: cfcontainerization/base-ci 
+    tag: latest
+inputs:
+- name: ci
+- name: docker-image-resource
+- name: cf-deployment
+- name: s3.stemcell-version
+- name: s3.fissile-linux
+params:
+  STEMCELL_OS:
+  STEMCELL_REPOSITORY:
+  CF_DEPLOYMENT_YAML:
+  DOCKER_ORGANIZATION:
+  DOCKER_TEAM_USERNAME:
+  DOCKER_TEAM_PASSWORD_RW:
+run:
+  path: ci/build-pipelines/release-images-cf-deployment/tasks/build.sh

--- a/build-pipelines/release-images-cf-deployment/tasks/build_release.sh
+++ b/build-pipelines/release-images-cf-deployment/tasks/build_release.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+function build_release() {
+  cf_version="${1}"
+  docker_registry="${2}"
+  docker_organization="${3}"
+  docker_username="${4}"
+  docker_password="${5}"
+  stemcell_os="${6}"
+  stemcell_version="${7}"
+  stemcell_image="${8}"
+  release_name="${9}"
+  release_url="${10}"
+  release_version="${11}"
+  release_sha1="${12}"
+
+  stemcell_name="${stemcell_os}-${stemcell_version}"
+
+  echo -e "Release information:"
+  echo -e "  - Release name:    ${GREEN}${release_name}${NC}"
+  echo -e "  - Release version: ${GREEN}${release_version}${NC}"
+  echo -e "  - Release URL:     ${GREEN}${release_url}${NC}"
+  echo -e "  - Release SHA1:    ${GREEN}${release_sha1}${NC}"
+
+  build_args=(
+    --stemcell="${stemcell_image}"
+    --name="${release_name}"
+    --version="${release_version}"
+    --sha1="${release_sha1}"
+    --url="${release_url}"
+    --docker-registry="${docker_registry}"
+    --docker-organization="${docker_organization}"
+  )
+
+  built_image=$(fissile build release-images --dry-run "${build_args[@]}" | cut -d' ' -f3)
+  built_image_tag="${built_image#*:}"
+  docker_creds_string=""${docker_username}":"${docker_password}""
+
+  # Check if there is an image already pushed for the release being built, otherwise push.
+  if curl --silent -u "${docker_creds_string}" "https://"${docker_registry}"/v2/"${docker_organization}"/"${release_name}"/manifests/"${built_image_tag}"" | jq '.errors[0].code' | grep -q null; then
+    echo -e "Skipping push for ${GREEN}${built_image}${NC} as it is already present in the registry..."
+  else
+      # Build the release image.
+      fissile build release-images "${build_args[@]}"
+
+      echo -e "Built image: ${GREEN}${built_image}${NC}"
+      docker push "${built_image}"
+      docker rmi "${built_image}"
+  fi
+
+  echo '----------------------------------------------------------------------------------------------------'
+}

--- a/build-pipelines/set-pipeline
+++ b/build-pipelines/set-pipeline
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -ox errexit -o nounset
+
+usage() {
+    cat <<EOF
+
+${0} [options]
+
+The pipeline configuration file "pipeline.yml.erb" must exist.
+The configuration file "config.yml" must exist.
+
+Available options:
+    -h, --help          Print this help and exit.
+    -t, --target=       Set fly target concourse.
+    -b, --branch=       Use a specific branch or tag. Defaults to the current branch.
+    -p, --pipeline=     Name of the directory containing pipeline definition.
+
+EOF
+}
+
+OPTS=$(getopt -o hp:t:b: --long help,target:,branch:,pipeline: -- "$@")
+eval set -- "${OPTS}"
+
+src_ci_branch=$(git rev-parse --abbrev-ref HEAD)
+target=""
+secrets_file=""
+while true ; do
+    case "${1}" in
+        -h|--help)   usage ; exit 0 ;;
+        -t|--target) target="${2}" ; shift 2 ;;
+        -p|--pipeline) pipeline="${2}" ; shift 2 ;;
+        -b|--branch) src_ci_branch="${2}" ; shift 2 ;;
+        --)          shift ; break ;;
+        *)           printf "Internal error: unexpected arguments %s\n" "$*" >&2 ; exit 1 ;;
+    esac
+done
+
+if [[ -z "${target}" ]] || [[ -z "${pipeline}" ]]; then
+    usage
+    exit 1
+fi
+
+pipeline_config="${pipeline}/config.yml"
+
+if test -n "${CONCOURSE_SECRETS_FILE:-}"; then
+    if test -r "${CONCOURSE_SECRETS_FILE:-}" ; then
+        secrets_file="${CONCOURSE_SECRETS_FILE}"
+    else
+        printf "ERROR: Secrets file %s is not readable\n" "${CONCOURSE_SECRETS_FILE}" >&2
+        exit 2
+    fi
+fi
+
+# generate_pipeline will emit the pipeline definition on STDOUT
+generate_pipeline() {
+  local pipeline_template="${pipeline}/pipeline.yml.erb"
+  ruby generate-pipeline.rb "${pipeline_template}" "${pipeline_config}" <(${secrets_file:+gpg --decrypt --batch ${secrets_file}})
+}
+
+# Branch is assumed to be the current branch if not specified, but the concourse git
+# resource doesn't allow commit references to be used directly.
+if [[ -z $src_ci_branch ]] ||
+    [[  $(echo $src_ci_branch | tr '[:upper:]' '[:lower:]') == head ]]; then
+  printf "Failed to determine ref for git resource to use.\n" >&2
+  printf "Checkout a branch or specify a branch/tag with '-b\n'" >&2
+  exit 1
+fi
+
+# Now that we have the branch/tag, check that it exists in the remote with the URL specified
+# in the config file's 'src_ci_repo'.
+
+src_ci_repo=$(
+  #Remove anchor references from vars file as they break parsing
+  grep -v '\*' ${pipeline_config} \
+  | ruby -r yaml -e "puts YAML.load(STDIN.read)['src-ci-repo']"
+)
+src_ci_remote=$(git remote -v | grep -F "$src_ci_repo (fetch)" | cut -f1 | head -1)
+
+# If a matching remote couldn't be found, create one
+if [[ -z $src_ci_remote ]]; then
+  src_ci_remote=${pool}-src-ci-repo
+  git remote add $src_ci_remote $src_ci_repo
+fi
+
+# Ensure we have the latest tag/branch updates from remote
+git fetch $src_ci_remote
+
+# Check that the tag/branch specified exists on the remote
+if ! git ls-remote --exit-code $src_ci_remote $src_ci_branch; then
+  printf "The branch/tag %s could not be found in repo %s\n" $src_ci_branch $src_ci_repo >&2
+  exit 1
+fi
+
+# Append tag/branch name to pipeline name
+pipeline_name=${pipeline}-${src_ci_branch//\//-}
+
+# Determine if pipeline already exists. This will be used to pause the jobs by default
+existing_pipeline_job_count=$(
+  fly ${target:+"--target=${target}"} get-pipeline --json -p "${pipeline_name}" | \
+    jq '.jobs | length'
+)
+if [[ ${existing_pipeline_job_count} -gt 0 ]]; then
+  pipeline_already_existed=true
+else
+  pipeline_already_existed=false
+fi
+
+fly \
+    ${target:+"--target=${target}"} \
+    set-pipeline \
+    --non-interactive \
+    --pipeline="${pipeline_name}" \
+    --config=<(generate_pipeline) \
+    --var src-ci-branch=${src_ci_branch}
+
+fly \
+    ${target:+"--target=$target"} \
+    expose-pipeline \
+    --pipeline="${pipeline_name}"
+
+if ! ${pipeline_already_existed}; then
+  job_names=$(
+    fly ${target:+"--target=${target}"} get-pipeline --json -p "${pipeline_name}" | \
+      jq -r '.jobs[] | .name'
+  )
+  for job_name in ${job_names}; do
+    fly ${target:+"--target=${target}"} pause-job -j "${pipeline_name}/${job_name}"
+  done
+  fly ${target:+"--target=${target}"} unpause-pipeline --pipeline="${pipeline_name}"
+fi


### PR DESCRIPTION
The PR intends to add code for v3 build pipelines. Also, it moves source control for SLE https://github.com/cloudfoundry-incubator/cf-operator-ci/tree/master/pipelines/release-images-cf-deployment pipeline over to cf-ci.