### PR TITLE
Added step to apply set_suse_buildpacks ops-file

### DIFF
--- a/build-pipelines/release-images-cf-deployment/config.yml
+++ b/build-pipelines/release-images-cf-deployment/config.yml
@@ -3,12 +3,17 @@ cf-deployment-tags:
   - v9.2.0
   - v9.5.0
 ci-repo: https://github.com/suse/cf-ci
-ci-branch: bisingh/cf-operator-ci
+ci-branch: develop
 docker-image-resource-repo: https://github.com/concourse/docker-image-resource
 docker-image-resource-branch: master
 cf-deployment-repo: https://github.com/cloudfoundry/cf-deployment
 cf-deployment-branch: master
 cf-deployment-yaml: cf-deployment/cf-deployment.yml
+bosh-cli-tag: 6.1.0
+scf-repo: https://github.com/SUSE/scf
+# TODO: need to replace this with v3-develop once #2792 is merged.
+scf-branch: f0rmiga/set-suse-buildpacks
+scf-ops-set-suse-buildpacks: deploy/helm/scf/assets/operations/buildpacks/set_suse_buildpacks.yaml
 fissile-linux-s3-bucket: cf-opensusefs2
 stemcell-os: SLE
 stemcell-repository: *docker-internal-fissile-image

--- a/build-pipelines/release-images-cf-deployment/config.yml
+++ b/build-pipelines/release-images-cf-deployment/config.yml
@@ -11,8 +11,7 @@ cf-deployment-branch: master
 cf-deployment-yaml: cf-deployment/cf-deployment.yml
 bosh-cli-tag: 6.1.0
 scf-repo: https://github.com/SUSE/scf
-# TODO: need to replace this with v3-develop once #2792 is merged.
-scf-branch: f0rmiga/set-suse-buildpacks
+scf-branch: v3-develop
 scf-ops-set-suse-buildpacks: deploy/helm/scf/assets/operations/buildpacks/set_suse_buildpacks.yaml
 fissile-linux-s3-bucket: cf-opensusefs2
 stemcell-os: SLE

--- a/build-pipelines/release-images-cf-deployment/pipeline.yml.erb
+++ b/build-pipelines/release-images-cf-deployment/pipeline.yml.erb
@@ -19,6 +19,13 @@ resources:
     branch: <%= cf_deployment_branch %>
     tag_filter: <%= cf_deployment_tag %>
 <% end %>
+- name: scf
+  type: git
+  source:
+    uri: <%= scf_repo %>
+    branch: <%= scf_branch %>
+    paths:
+    - <%= scf_ops_set_suse_buildpacks %>
 - name: s3.fissile-linux
   type: s3
   source:
@@ -33,7 +40,7 @@ resources:
     access_key_id: <%= s3_access_key %>
     secret_access_key: <%= s3_secret_key %>
     versioned_file: <%= stemcell_version_file %>
-    
+
 jobs:
 <% cf_deployment_tags.each do |cf_deployment_tag| %>
 - name: build-<%= cf_deployment_tag %>
@@ -42,6 +49,8 @@ jobs:
     - get: ci
     - get: docker-image-resource
     - get: cf-deployment-<%= cf_deployment_tag %>
+    - get: scf
+      trigger: true
     - get: s3.fissile-stemcell-version
       trigger: true
     - get: s3.fissile-linux
@@ -57,6 +66,8 @@ jobs:
         STEMCELL_REPOSITORY: <%= stemcell_repository %>
         STEMCELL_VERSIONED_FILE: <%= stemcell_version_file %>
         CF_DEPLOYMENT_YAML: <%= cf_deployment_yaml %>
+        BOSH_CLI_TAG: <%= bosh_cli_tag %>
+        SCF_OPS_SET_SUSE_BUILDPACKS: <%= scf_ops_set_suse_buildpacks %>
         DOCKER_REGISTRY: <%= docker_registry %>
         DOCKER_ORGANIZATION: <%= docker_organization %>
         DOCKER_TEAM_USERNAME: <%= docker_username %>

--- a/build-pipelines/release-images-cf-deployment/tasks/build.sh
+++ b/build-pipelines/release-images-cf-deployment/tasks/build.sh
@@ -21,11 +21,18 @@ echo "${DOCKER_TEAM_PASSWORD_RW}" | docker login "${DOCKER_REGISTRY}" --username
 # Extract the fissile binary.
 tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
 
+# Download bosh-cli.
+curl -sL "https://github.com/cloudfoundry/bosh-cli/releases/download/v${BOSH_CLI_TAG}/bosh-cli-${BOSH_CLI_TAG}-linux-amd64" --output "/usr/local/bin/bosh" && chmod +x "/usr/local/bin/bosh"
+
 # Pull the stemcell image.
 stemcell_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}")"
 stemcell_image="${STEMCELL_REPOSITORY}:${stemcell_version}"
 docker pull "${stemcell_image}"
 
+# Apply buildpacks ops-file.
+cf_deployment_yaml_with_suse_buildpacks="$(mktemp /tmp/buildpacks.XXXXXX)"
+bosh interpolate "${CF_DEPLOYMENT_YAML}" --ops-file "scf/${SCF_OPS_SET_SUSE_BUILDPACKS}" > "${cf_deployment_yaml_with_suse_buildpacks}"
+
 # Build the releases.
 tasks_dir="$(dirname $0)"
-bash <(yq -r ".manifest_version as \$cf_version | .releases[] | \"source ${tasks_dir}/build_release.sh; build_release \\(\$cf_version|@sh) '${DOCKER_REGISTRY}' '${DOCKER_ORGANIZATION}' '${DOCKER_TEAM_USERNAME}' '${DOCKER_TEAM_PASSWORD_RW}' '${STEMCELL_OS}' '${stemcell_version}' '${stemcell_image}' \\(.name|@sh) \\(.url|@sh) \\(.version|@sh) \\(.sha1|@sh)\"" "${CF_DEPLOYMENT_YAML}")
+bash <(yq -r ".manifest_version as \$cf_version | .releases[] | \"source ${tasks_dir}/build_release.sh; build_release \\(\$cf_version|@sh) '${DOCKER_REGISTRY}' '${DOCKER_ORGANIZATION}' '${DOCKER_TEAM_USERNAME}' '${DOCKER_TEAM_PASSWORD_RW}' '${STEMCELL_OS}' '${stemcell_version}' '${stemcell_image}' \\(.name|@sh) \\(.url|@sh) \\(.version|@sh) \\(.sha1|@sh)\"" "${cf_deployment_yaml_with_suse_buildpacks}")

--- a/build-pipelines/release-images-cf-deployment/tasks/build.yml
+++ b/build-pipelines/release-images-cf-deployment/tasks/build.yml
@@ -3,20 +3,25 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfcontainerization/base-ci 
+    repository: cfcontainerization/base-ci
     tag: latest
 inputs:
 - name: ci
 - name: docker-image-resource
 - name: cf-deployment
+- name: scf
 - name: s3.stemcell-version
 - name: s3.fissile-linux
 params:
-  STEMCELL_OS:
-  STEMCELL_REPOSITORY:
-  CF_DEPLOYMENT_YAML:
-  DOCKER_ORGANIZATION:
-  DOCKER_TEAM_USERNAME:
-  DOCKER_TEAM_PASSWORD_RW:
+  STEMCELL_OS: ~
+  STEMCELL_REPOSITORY: ~
+  STEMCELL_VERSIONED_FILE: ~
+  CF_DEPLOYMENT_YAML: ~
+  BOSH_CLI_TAG: ~
+  SCF_OPS_SET_SUSE_BUILDPACKS: ~
+  DOCKER_REGISTRY: ~
+  DOCKER_ORGANIZATION: ~
+  DOCKER_TEAM_USERNAME: ~
+  DOCKER_TEAM_PASSWORD_RW: ~
 run:
   path: ci/build-pipelines/release-images-cf-deployment/tasks/build.sh

--- a/build-pipelines/set-pipeline
+++ b/build-pipelines/set-pipeline
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ox errexit -o nounset
+set -o errexit -o nounset
 
 usage() {
     cat <<EOF


### PR DESCRIPTION
The PR intends to update the `release-images-cf-deployment` pipeline to build SUSE buildpacks instead of upstream. It makes use of BOSH to apply an ops file to override buildpack release definitions.

ref: https://github.com/SUSE/scf/pull/2792

**Details:** https://jira.suse.com/browse/CAP-682