### PR TITLE
Remove remainder of concourse-level templating

### DIFF
--- a/qa-pipelines/qa-pipeline.yml.erb
+++ b/qa-pipelines/qa-pipeline.yml.erb
@@ -62,7 +62,7 @@ aliases:
 
     CAP_BUNDLE_URL: <%= bundle_url_from_version("#{s3_config_bucket_sles}.s3.amazonaws.com", cap_install_url || enable_cf_deploy) %>
     <% if klog_collection_on_failure %>
-    KLOG_COLLECTION_ON_FAILURE: <%= s3_config_bucket_sles %>-klogs-archive/((s3-klog-prefix))
+    KLOG_COLLECTION_ON_FAILURE: <%= s3_config_bucket_sles %>-klogs-archive/<%= s3_klog_prefix %>
     <% else %>
     KLOG_COLLECTION_ON_FAILURE: false
     <% end %> # klog_collection_on_failure
@@ -123,7 +123,7 @@ resources:
   type: git
   source:
     uri: <%= src_ci_repo %>
-    branch: ((src-ci-branch))
+    branch: <%= src_ci_branch %>
     paths:
     - qa-pipelines/*
     - sample-apps/*
@@ -146,7 +146,7 @@ resources:
   type: s3
   source:
     << : *s3-common-params
-    regexp: ((s3-config-prefix-sles))scf-sle-(.*)\.zip$
+    regexp: <%= s3_config_prefix_sles %>scf-sle-(.*)\.zip$
 
 # Pool resource with kube cluster information
 - name: pool.kube-hosts
@@ -185,12 +185,12 @@ resources:
   source:
     << : *s3-common-params
     bucket: <%= s3_config_bucket_sles %>-klogs-archive
-    regexp: ((s3-klog-prefix))/klog-(.*)\.tar\.gz$
+    regexp: <%= s3_klog_prefix %>/klog-(.*)\.tar\.gz$
 <% end %> # klog_collection_on_failure
 
 jobs:
 <% %w(SA HA).each do |avail| %>
-- name: ((pipeline-name))-<%= avail %>
+- name: <%= pipeline_name %>-<%= avail %>
   plan:
   - do:
     - aggregate:
@@ -225,8 +225,8 @@ jobs:
     <% if status_reporting %>
     - put: status.src
       params: &status-params-<%= avail %>
-        context: ((pipeline-name))-<%= avail %>
-        description: "QA Pipeline: ((pipeline-name)) (SLES <%= avail %>)"
+        context: <%= pipeline_name %>-<%= avail %>
+        description: "QA Pipeline: <%= pipeline_name %> (SLES <%= avail %>)"
         path: commit-id/sha
         state: pending
     <% end %> # status_reporting

--- a/qa-pipelines/set-pipeline
+++ b/qa-pipelines/set-pipeline
@@ -83,6 +83,14 @@ if test -n "${CONCOURSE_SECRETS_FILE:-}"; then
     fi
 fi
 
+pipeline_config() {
+   cat "config.yml"
+   echo "src-ci-branch: ${src_ci_branch}"
+   echo "s3-config-prefix-sles: ${s3_config_prefix}"
+   echo "s3-klog-prefix: ${s3_config_prefix%%/*}"
+   echo "pipeline-name: ${pipeline_name}"
+}
+
 # generate_pipeline will emit the pipeline definition on STDOUT; this deals with
 # the single-brain special case.
 generate_pipeline() {
@@ -94,7 +102,7 @@ generate_pipeline() {
     preset_template='pipeline-presets/single-brain.yml'
     flags='pipeline-presets/single-brain.yml'
   fi
-  ruby generate-pipeline.rb "${pipeline_template}" "${preset_template}" "${flags}" "config.yml" "${pool_vars_file}" <(${secrets_file:+gpg --decrypt --batch ${secrets_file}})
+  ruby generate-pipeline.rb "${pipeline_template}" "${preset_template}" "${flags}" <(pipeline_config) "${pool_vars_file}" <(${secrets_file:+gpg --decrypt --batch ${secrets_file}})
 }
 
 # Branch is assumed to be the current branch if not specified, but the concourse git
@@ -150,11 +158,7 @@ fly \
     set-pipeline \
     --non-interactive \
     --pipeline="${pipeline_name}" \
-    --var pipeline-name="${pipeline_name}" \
-    --config=<(generate_pipeline) \
-    --var src-ci-branch=${src_ci_branch} \
-    --var s3-config-prefix-sles=${s3_config_prefix} \
-    --var s3-klog-prefix=${s3_config_prefix%%/*}
+    --config=<(generate_pipeline)
 
 fly \
     ${target:+"--target=$target"} \


### PR DESCRIPTION
Having two layers of templating makes things more confusing. We can now
rely solely on ERB, by putting variables which need to be constructed
during the set-pipeline script into a temporary doc which is
concatenated with config.yml in order to make these parameters available
to the generate-pipeline script for ERB templating