### PR TITLE
Increase deploy and upgrade timeouts

### DIFF
--- a/qa-pipelines/qa-pipeline.yml.erb
+++ b/qa-pipelines/qa-pipeline.yml.erb
@@ -276,7 +276,7 @@ jobs:
         TEST_NAME: acceptance-tests-brain
       input_mapping:
         s3.scf-config: s3.scf-config-sles
-      timeout: 1h
+      timeout: 3h
     <% end %> # enable_cf_brain_tests_pre_upgrade
     <% if enable_cf_usb_upgrade_tests %>
     - task: usb-deploy-pre-upgrade
@@ -337,7 +337,7 @@ jobs:
         TEST_NAME: acceptance-tests-brain
       input_mapping:
         s3.scf-config: s3.scf-config-sles
-      timeout: 1h
+      timeout: 3h
     <% end %> # enable_cf_brain_tests
     <% if enable_cf_acceptance_tests %>
     - task: acceptance-tests
@@ -347,7 +347,7 @@ jobs:
         TEST_NAME: acceptance-tests
       input_mapping:
         s3.scf-config: s3.scf-config-sles
-      timeout: 2h
+      timeout: 3h
     <% end %> # enable_cf_acceptance_tests
     # We intentionally don't put the teardown and pool release steps in an ensure
     # block, so that when tests fail we have a chance of examining why things are

--- a/qa-pipelines/qa-pipeline.yml.erb
+++ b/qa-pipelines/qa-pipeline.yml.erb
@@ -256,7 +256,7 @@ jobs:
         HA: <%= avail == 'HA' %>
       input_mapping:
         s3.scf-config: s3.scf-config-sles
-      timeout: 3h
+      timeout: 5h
     <% end %> # enable_cf_deploy_pre_upgrade
     <% if enable_cf_smoke_tests_pre_upgrade %>
     - task: cf-smoke-tests-pre-upgrade
@@ -299,7 +299,7 @@ jobs:
         HA: <%= avail == 'HA' %>
       input_mapping:
         s3.scf-config: s3.scf-config-sles
-      timeout: 3h
+      timeout: 5h
     <% end %> # enable_cf_upgrade
     <% if enable_cf_usb_upgrade_tests %>
     - task: usb-post-upgrade
@@ -317,7 +317,7 @@ jobs:
         HA: <%= avail == 'HA' %>
       input_mapping:
         s3.scf-config: s3.scf-config-sles
-      timeout: 3h
+      timeout: 5h
     <% end %> # enable_cf_deploy
     <% if enable_cf_smoke_tests %>
     - task: cf-smoke-tests


### PR DESCRIPTION
Some platforms with slow networks take forever to pull images