### PR TITLE
Specify container name for kubectl attach

### DIFF
--- a/qa-pipelines/tasks/run-test.sh
+++ b/qa-pipelines/tasks/run-test.sh
@@ -157,7 +157,7 @@ kubectl run \
     "${TEST_NAME}" ||:
 
 while [[ -z $(container_status ${TEST_NAME}) ]]; do
-    kubectl attach --namespace=scf ${TEST_NAME} ||:
+    kubectl attach --namespace="${CF_NAMESPACE}" --container="${TEST_NAME}" "${TEST_NAME}" ||:
 done
 
 pod_status=$(container_status ${TEST_NAME})


### PR DESCRIPTION
Some version of kubectl appears to have a bug which causes a warning
message to repeat if the container name isn't specified (for some
reason, even if the pod has only one container), when kubectl attach is
used. Since our test container names match the test names, we can
specify them for right now to prevent the repeated warning from filling
up the concourse disk with useless logs.