### PR TITLE
Fixing wrong pipeline trigger issue on `kubecf`

### DIFF
--- a/build-pipelines/buildpacks/pipeline.yml.erb
+++ b/build-pipelines/buildpacks/pipeline.yml.erb
@@ -101,8 +101,6 @@ resources:
   source:
     uri: <%= kubecf_repo %>
     branch: <%= kubecf_branch %>
-    paths:
-    - <%= kubecf_ops_set_suse_buildpacks %>
     private_key: |
       <%= github_private_key.gsub("\n", "\n      ") %>
 

--- a/build-pipelines/buildpacks/tasks/create_pr.sh
+++ b/build-pipelines/buildpacks/tasks/create_pr.sh
@@ -76,6 +76,7 @@ COMMIT_TITLE="Bump ${NAME_IN_ROLE_MANIFEST} release to ${RELEASE_VERSION}"
 cp -r kubecf/. updated-kubecf/
 cd updated-kubecf
 
+git pull
 export GIT_BRANCH_NAME="bump_${NAME_IN_ROLE_MANIFEST}-`date +%Y%m%d%H%M%S`"
 git checkout -b "${GIT_BRANCH_NAME}"
 


### PR DESCRIPTION
This fixes the issue where `master` was not being updated correctly before opening PR to update buildpacks.