### PR TITLE
Enabling docker cli experimental features

### DIFF
--- a/kubecf-build-pipelines/buildpacks/tasks/build_release.sh
+++ b/kubecf-build-pipelines/buildpacks/tasks/build_release.sh
@@ -31,7 +31,6 @@ function build_release() {
   )
 
   built_image=$(fissile build release-images --dry-run "${build_args[@]}" | cut -d' ' -f3)
-  built_image_tag="${built_image#*:}"
 
   export DOCKER_CLI_EXPERIMENTAL=enabled;
   # Only build and push the container image if doesn't exits already.

--- a/kubecf-build-pipelines/buildpacks/tasks/build_release.sh
+++ b/kubecf-build-pipelines/buildpacks/tasks/build_release.sh
@@ -33,6 +33,7 @@ function build_release() {
   built_image=$(fissile build release-images --dry-run "${build_args[@]}" | cut -d' ' -f3)
   built_image_tag="${built_image#*:}"
 
+  export DOCKER_CLI_EXPERIMENTAL=enabled;
   # Only build and push the container image if doesn't exits already.
   if docker manifest inspect "${built_image}" 2>&1 | grep --quiet "no such manifest"; then
       # Build the release image.

--- a/kubecf-build-pipelines/release-images-cf-deployment/tasks/build_release.sh
+++ b/kubecf-build-pipelines/release-images-cf-deployment/tasks/build_release.sh
@@ -35,6 +35,7 @@ function build_release() {
   built_image=$(fissile build release-images --dry-run "${build_args[@]}" | cut -d' ' -f3)
   built_image_tag="${built_image#*:}"
 
+  export DOCKER_CLI_EXPERIMENTAL=enabled;  
   # Only build and push the container image if doesn't exits already.
   if docker manifest inspect "${built_image}" 2>&1 | grep --quiet "no such manifest"; then
       # Build the release image.

--- a/kubecf-build-pipelines/release-images-cf-deployment/tasks/build_release.sh
+++ b/kubecf-build-pipelines/release-images-cf-deployment/tasks/build_release.sh
@@ -33,7 +33,6 @@ function build_release() {
   )
 
   built_image=$(fissile build release-images --dry-run "${build_args[@]}" | cut -d' ' -f3)
-  built_image_tag="${built_image#*:}"
 
   export DOCKER_CLI_EXPERIMENTAL=enabled;  
   # Only build and push the container image if doesn't exits already.


### PR DESCRIPTION
The experimental features in docker cli needs to be enabled to be able to use `docker manifest inspect`.