### PR TITLE
kubecf: fix build image

### DIFF
--- a/kubecf-build-pipelines/buildpacks/config.yml
+++ b/kubecf-build-pipelines/buildpacks/config.yml
@@ -1,5 +1,7 @@
 ci-repo: https://github.com/suse/cf-ci
 ci-branch: develop
+build-image-resource-repo: https://github.com/concourse/docker-image-resource
+build-image-resource-branch: master
 kubecf-repo: git@github.com:SUSE/kubecf.git
 kubecf-branch: master
 kubecf-ops-set-suse-buildpacks: deploy/helm/kubecf/assets/operations/buildpacks/set_suse_buildpacks.yaml

--- a/kubecf-build-pipelines/buildpacks/pipeline.yml.erb
+++ b/kubecf-build-pipelines/buildpacks/pipeline.yml.erb
@@ -77,6 +77,11 @@ resources:
   source:
     uri: <%= ci_repo %>
     branch: <%= ci_branch %>
+- name: build-image-resource	
+  type: git	
+  source:	
+    uri: <%= build_image_resource_repo %>	
+    branch: <%= build_image_resource_branch %>
 - name: s3.fissile-linux
   type: s3
   source:
@@ -124,6 +129,7 @@ jobs:
   plan:
   - in_parallel:
     - get: ci
+    - get: build-image-resource
     - get: s3.fissile-stemcell-version
       trigger: true
     - get: s3.fissile-linux

--- a/kubecf-build-pipelines/buildpacks/tasks/build.sh
+++ b/kubecf-build-pipelines/buildpacks/tasks/build.sh
@@ -2,12 +2,18 @@
 
 set -o errexit -o nounset
 
-# Start Docker Daemon (and set a trap to stop it once this script is done)
-echo 'DOCKER_OPTS="--data-root /scratch/docker --max-concurrent-downloads 10"' >/etc/default/docker
-service docker start
-service docker status
-trap 'service docker stop' EXIT
-sleep 10
+# Start the Docker daemon.
+source build-image-resource/assets/common.sh
+max_concurrent_downloads=10
+max_concurrent_uploads=10
+insecure_registries=""
+registry_mirror=""
+start_docker \
+  "${max_concurrent_downloads}" \
+  "${max_concurrent_uploads}" \
+  "${insecure_registries}" \
+  "${registry_mirror}"
+trap 'stop_docker' EXIT
 
 # Login to the Docker registry.
 echo "${REGISTRY_PASS}" | docker login "${REGISTRY_NAME}" --username "${REGISTRY_USER}" --password-stdin

--- a/kubecf-build-pipelines/buildpacks/tasks/build.yml
+++ b/kubecf-build-pipelines/buildpacks/tasks/build.yml
@@ -3,10 +3,11 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: registry.suse.com/cap-staging/cf-ci
+    repository: splatform/base-ci
     tag: kubecf
 inputs:
 - name: ci
+- name: build-image-resource
 - name: s3.stemcell-version
 - name: s3.fissile-linux
 - name: gh_release

--- a/kubecf-build-pipelines/buildpacks/tasks/create_pr.yml
+++ b/kubecf-build-pipelines/buildpacks/tasks/create_pr.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: registry.suse.com/cap-staging/cf-ci
+    repository: splatform/base-ci
     tag: kubecf
 inputs:
 - name: ci

--- a/kubecf-build-pipelines/cf-deployment/config.yml
+++ b/kubecf-build-pipelines/cf-deployment/config.yml
@@ -4,6 +4,8 @@ cf-deployment-tags:
   - v9.5.0
 ci-repo: https://github.com/suse/cf-ci
 ci-branch: develop
+build-image-resource-repo: https://github.com/concourse/docker-image-resource	
+build-image-resource-branch: master
 cf-deployment-repo: https://github.com/cloudfoundry/cf-deployment
 cf-deployment-branch: master
 cf-deployment-yaml: cf-deployment/cf-deployment.yml

--- a/kubecf-build-pipelines/cf-deployment/pipeline.yml.erb
+++ b/kubecf-build-pipelines/cf-deployment/pipeline.yml.erb
@@ -6,6 +6,11 @@ resources:
   source:
     uri: <%= ci_repo %>
     branch: <%= ci_branch %>
+- name: build-image-resource	
+  type: git	
+  source:	
+    uri: <%= build_image_resource_repo %>	
+    branch: <%= build_image_resource_branch %>
 <% cf_deployment_tags.each do |cf_deployment_tag| %>
 - name: cf-deployment-<%= cf_deployment_tag %>
   type: git
@@ -35,6 +40,7 @@ jobs:
   plan:
   - in_parallel:
     - get: ci
+    - get: build-image-resource
     - get: cf-deployment-<%= cf_deployment_tag %>
     - get: s3.fissile-stemcell-version
       trigger: true

--- a/kubecf-build-pipelines/cf-deployment/tasks/build.sh
+++ b/kubecf-build-pipelines/cf-deployment/tasks/build.sh
@@ -2,12 +2,18 @@
 
 set -o errexit -o nounset
 
-# Start Docker Daemon (and set a trap to stop it once this script is done)
-echo 'DOCKER_OPTS="--data-root /scratch/docker --max-concurrent-downloads 10"' >/etc/default/docker
-service docker start
-service docker status
-trap 'service docker stop' EXIT
-sleep 10
+# Start the Docker daemon.
+source build-image-resource/assets/common.sh
+max_concurrent_downloads=10
+max_concurrent_uploads=10
+insecure_registries=""
+registry_mirror=""
+start_docker \
+  "${max_concurrent_downloads}" \
+  "${max_concurrent_uploads}" \
+  "${insecure_registries}" \
+  "${registry_mirror}"
+trap 'stop_docker' EXIT
 
 # Login to the Docker registry.
 echo "${REGISTRY_PASS}" | docker login "${REGISTRY_NAME}" --username "${REGISTRY_USER}" --password-stdin

--- a/kubecf-build-pipelines/cf-deployment/tasks/build.yml
+++ b/kubecf-build-pipelines/cf-deployment/tasks/build.yml
@@ -3,10 +3,11 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: registry.suse.com/cap-staging/cf-ci
+    repository: splatform/base-ci
     tag: kubecf
 inputs:
 - name: ci
+- name: build-image-resource
 - name: cf-deployment
 - name: s3.stemcell-version
 - name: s3.fissile-linux

--- a/kubecf-build-pipelines/external-releases/config.yml
+++ b/kubecf-build-pipelines/external-releases/config.yml
@@ -1,5 +1,7 @@
 ci-repo: https://github.com/suse/cf-ci
 ci-branch: develop
+build-image-resource-repo: https://github.com/concourse/docker-image-resource
+build-image-resource-branch: master
 external-releases-yaml: kubecf-build-pipelines/external-releases/external-releases.yml
 fissile-linux-s3-bucket: cf-opensusefs2
 stemcell-repository: registry.suse.com/cap-staging/fissile-stemcell-sle12

--- a/kubecf-build-pipelines/external-releases/pipeline.yml.erb
+++ b/kubecf-build-pipelines/external-releases/pipeline.yml.erb
@@ -6,6 +6,11 @@ resources:
   source:
     uri: <%= ci_repo %>
     branch: <%= ci_branch %>
+- name: build-image-resource	
+  type: git	
+  source:	
+    uri: <%= build_image_resource_repo %>	
+    branch: <%= build_image_resource_branch %>
 - name: s3.fissile-linux
   type: s3
   source:
@@ -35,6 +40,7 @@ jobs:
   plan:
   - in_parallel:
     - get: ci
+    - get: build-image-resource
     - get: s3.fissile-stemcell-version
       trigger: true
     - get: s3.fissile-linux

--- a/kubecf-build-pipelines/external-releases/tasks/build.sh
+++ b/kubecf-build-pipelines/external-releases/tasks/build.sh
@@ -2,12 +2,18 @@
 
 set -o errexit -o nounset
 
-# Start Docker Daemon (and set a trap to stop it once this script is done)
-echo 'DOCKER_OPTS="--data-root /scratch/docker --max-concurrent-downloads 10"' >/etc/default/docker
-systemctl docker start
-systemctl docker status
-trap 'systemctl docker stop' EXIT
-sleep 10
+# Start the Docker daemon.
+source build-image-resource/assets/common.sh
+max_concurrent_downloads=10
+max_concurrent_uploads=10
+insecure_registries=""
+registry_mirror=""
+start_docker \
+  "${max_concurrent_downloads}" \
+  "${max_concurrent_uploads}" \
+  "${insecure_registries}" \
+  "${registry_mirror}"
+trap 'stop_docker' EXIT
 
 # Login to the Docker registry.
 echo "${REGISTRY_PASS}" | docker login "${REGISTRY_NAME}" --username "${REGISTRY_USER}" --password-stdin

--- a/kubecf-build-pipelines/external-releases/tasks/build.sh
+++ b/kubecf-build-pipelines/external-releases/tasks/build.sh
@@ -4,9 +4,9 @@ set -o errexit -o nounset
 
 # Start Docker Daemon (and set a trap to stop it once this script is done)
 echo 'DOCKER_OPTS="--data-root /scratch/docker --max-concurrent-downloads 10"' >/etc/default/docker
-service docker start
-service docker status
-trap 'service docker stop' EXIT
+systemctl docker start
+systemctl docker status
+trap 'systemctl docker stop' EXIT
 sleep 10
 
 # Login to the Docker registry.

--- a/kubecf-build-pipelines/external-releases/tasks/build.yml
+++ b/kubecf-build-pipelines/external-releases/tasks/build.yml
@@ -7,6 +7,7 @@ image_resource:
     tag: kubecf
 inputs:
 - name: ci
+- name: build-image-resource
 - name: s3.stemcell-version
 - name: s3.fissile-linux
 - name: external-releases

--- a/kubecf-build-pipelines/external-releases/tasks/build.yml
+++ b/kubecf-build-pipelines/external-releases/tasks/build.yml
@@ -3,8 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    # derived from havener/build-environment
-    repository: registry.suse.com/cap-staging/cf-ci
+    repository: splatform/base-ci
     tag: kubecf
 inputs:
 - name: ci


### PR DESCRIPTION
We started noticing issues in building images after switching over to `havener/build-environment` image for building release images.

This PR switch back to using `splatform/base-ci:kubecf` image which has already been updated with all required dependencies.