### PR TITLE
Remove timeout for upgrade app downtime monitoring

### DIFF
--- a/qa-pipelines/tasks/cf-upgrade.sh
+++ b/qa-pipelines/tasks/cf-upgrade.sh
@@ -22,10 +22,6 @@ monitor_url() {
       last_state=$new_state
     fi
     ((++count))
-    if [[ ${count} -gt 10800 ]]; then
-      echo "Ending monitor of ${app_url} due to timeout"
-      break
-    fi
     sleep 1
   done
 }


### PR DESCRIPTION
If the app isn't back online, we have problems with the upgrade, so we
should keep monitoring until the cf-upgrade task timeout hits (or helm
upgrade timeout if applicable). Monitoring should not complete
successfully unless the app is back up.