### PR TITLE
Refactoring kubecf build pipelines

### DIFF
--- a/kubecf-build-pipelines/cf-deployment/config.yml
+++ b/kubecf-build-pipelines/cf-deployment/config.yml
@@ -2,6 +2,7 @@ cf-deployment-tags:
   - v8.0.0
   - v9.2.0
   - v9.5.0
+  - v12.18.0
 ci-repo: https://github.com/suse/cf-ci
 ci-branch: develop
 build-image-resource-repo: https://github.com/concourse/docker-image-resource	
@@ -14,9 +15,9 @@ stemcell-repository: splatform/fissile-stemcell-sle
 stemcell-versions-s3-bucket: cf-operators
 stemcell-version-file: fissile-stemcell-versions/fissile-stemcell-sle15-version
 stemcell-s3-bucket-region: us-east-1
-registry-name: *docker-public-staging-registry
-registry-org: *docker-public-staging-org
-registry-user: *docker-public-staging-username
-registry-pass: *docker-public-staging-password
+registry-name: docker.io
+registry-org: *docker-cfcontainerization-org
+registry-user: *docker-cfcontainerization-username
+registry-pass: *docker-cfcontainerization-password
 s3-access-key: *aws-capbot-access-key
 s3-secret-key: *aws-capbot-secret-key

--- a/kubecf-build-pipelines/external-releases/external-releases.yml
+++ b/kubecf-build-pipelines/external-releases/external-releases.yml
@@ -21,13 +21,25 @@ releases:
   version: 0.0.7
   sha1: 6d3cd621c3eb011744d31c8746f3a96ecc804ea9
 - name: brains-tests-release
+  url: https://s3.amazonaws.com/suse-final-releases/brain-tests-release-v0.0.6.tgz
+  version: v0.0.6
+  sha1: c18d0054174b23359c5b7602fcdefdb75527788e
+- name: brains-tests-release
   url: https://s3.amazonaws.com/suse-final-releases/brain-tests-release-v0.0.8.tgz
   version: v0.0.8
   sha1: 706218d94e13782d65daf926279adcd41ef3911a
 - name: postgres
+  url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=39
+  version: 39
+  sha1: 8ff395540e77a461322a01c41aa68973c10f1ffb
+- name: postgres
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=40
   version: 40
   sha1: 343f04f1594c57ecea65638802e94e311cd72688
+- name: bits-service
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=2.28.0
+  version: 2.28.0
+  sha1: bd173fc9952277ea962a330c04555d9bd1e8a10e
 - name: bits-service
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/bits-service-release?v=2.29.0
   version: 2.29.0

--- a/kubecf-build-pipelines/external-releases/external-releases.yml
+++ b/kubecf-build-pipelines/external-releases/external-releases.yml
@@ -3,11 +3,6 @@ releases:
   url: https://bosh.io/d/github.com/pivotal-cf/credhub-release?v=2.5.11
   version: 2.5.11
   sha1: f1810c1e662a1c76f40911cffd1d159204c9a661
-# Leaving cf-mysql-release out due to build failure issues.  
-# - name: cf-mysql-release
-#   url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.19.0
-#   version: 36.19.0
-#   sha1: 393a018015fdcb48da40259b6a39b8e30fde9d0c
 - name: app-autoscaler
   version: 3.0.0
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=3.0.0
@@ -20,14 +15,6 @@ releases:
   url: https://s3.amazonaws.com/suse-final-releases/cf-acceptance-tests-release-0.0.7.tgz
   version: 0.0.7
   sha1: 6d3cd621c3eb011744d31c8746f3a96ecc804ea9
-- name: brains-tests-release
-  url: https://s3.amazonaws.com/suse-final-releases/brain-tests-release-v0.0.6.tgz
-  version: v0.0.6
-  sha1: c18d0054174b23359c5b7602fcdefdb75527788e
-- name: brains-tests-release
-  url: https://s3.amazonaws.com/suse-final-releases/brain-tests-release-v0.0.8.tgz
-  version: v0.0.8
-  sha1: 706218d94e13782d65daf926279adcd41ef3911a
 - name: postgres
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=39
   version: 39
@@ -52,6 +39,19 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry-community/eirini-bosh-release?v=0.0.25
   version: 0.0.25
   sha1: ee832521e2a63e4eccbea16f4dd1b26606f7bd99
+# Leaving few releases out due to build failure issues, see: https://github.com/SUSE/kubecf/issues/270
+# - name: cf-mysql-release
+#   url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.19.0
+#   version: 36.19.0
+#   sha1: 393a018015fdcb48da40259b6a39b8e30fde9d0c
+# - name: brains-tests-release
+#   url: https://s3.amazonaws.com/suse-final-releases/brain-tests-release-v0.0.6.tgz
+#   version: v0.0.6
+#   sha1: c18d0054174b23359c5b7602fcdefdb75527788e
+# - name: brains-tests-release
+#   url: https://s3.amazonaws.com/suse-final-releases/brain-tests-release-v0.0.8.tgz
+#   version: v0.0.8
+#   sha1: 706218d94e13782d65daf926279adcd41ef3911a
 # TODO: replace url once final release is available.
 - name: sync-integration-tests-release
   url: https://s3-us-west-2.amazonaws.com/dummy-releases/sync-integration-tests-release-v0.0.2.tgz

--- a/kubecf-build-pipelines/external-releases/external-releases.yml
+++ b/kubecf-build-pipelines/external-releases/external-releases.yml
@@ -8,6 +8,10 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=3.0.0
   sha1: eb532308d63a8a3db6645c118b3429d0ab2d5937
 - name: cf-sle15-release
+  url: https://s3.amazonaws.com/suse-final-releases/sle15-release-10.93.tgz
+  version: 10.93
+  sha1: 601c0d7e990203cb09ebfaa099a14b780e95e500
+- name: cf-sle15-release
   url: https://s3.amazonaws.com/suse-final-releases/sle15-release-10.100.tgz
   version: 10.100
   sha1: a60edb70a1d7d3506dd7018a7e042a791031e5bb

--- a/kubecf-build-pipelines/external-releases/external-releases.yml
+++ b/kubecf-build-pipelines/external-releases/external-releases.yml
@@ -43,7 +43,8 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry-community/eirini-bosh-release?v=0.0.25
   version: 0.0.25
   sha1: ee832521e2a63e4eccbea16f4dd1b26606f7bd99
-# Leaving few releases out due to build failure issues, see: https://github.com/SUSE/kubecf/issues/270
+# Leaving few releases out due to build failure issues, see: https://github.com/SUSE/kubecf/issues/270.
+# TODO: fix them.
 # - name: cf-mysql-release
 #   url: https://bosh.io/d/github.com/cloudfoundry/cf-mysql-release?v=36.19.0
 #   version: 36.19.0


### PR DESCRIPTION
Changes:
- Adding more versions of existing external releases.
- Switch to DockerHub for cf-deployment build pipeline.
- Adding v12.18.0 for cf-deployment pipeline.