### PR TITLE
Making stemcell version configurable.

### DIFF
--- a/kubecf-build-pipelines/buildpacks/config.yml
+++ b/kubecf-build-pipelines/buildpacks/config.yml
@@ -7,9 +7,7 @@ kubecf-branch: master
 kubecf-values: deploy/helm/kubecf/values.yaml
 fissile-linux-s3-bucket: cf-opensusefs2
 stemcell-repository: splatform/fissile-stemcell-sle
-stemcell-versions-s3-bucket: cf-operators
-stemcell-version-file: fissile-stemcell-versions/fissile-stemcell-sle15-version
-stemcell-s3-bucket-region: us-east-1
+stemcell-version: SLE_15_SP1-23.8
 registry-name: *docker-public-staging-registry
 registry-org: *docker-public-staging-org
 registry-user: *docker-public-staging-username

--- a/kubecf-build-pipelines/buildpacks/pipeline.yml.erb
+++ b/kubecf-build-pipelines/buildpacks/pipeline.yml.erb
@@ -88,14 +88,6 @@ resources:
     bucket: <%= fissile_linux_s3_bucket %>
     private: true
     regexp: fissile/develop/fissile-(.*)\.tgz
-- name: s3.fissile-stemcell-version
-  type: s3
-  source:
-    bucket: <%= stemcell_versions_s3_bucket %>
-    region_name: <%= stemcell_s3_bucket_region %>
-    access_key_id: <%= s3_access_key %>
-    secret_access_key: <%= s3_secret_key %>
-    versioned_file: <%= stemcell_version_file %>
 - name: kubecf
   type: git
   source:
@@ -130,8 +122,6 @@ jobs:
   - in_parallel:
     - get: ci
     - get: build-image-resource
-    - get: s3.fissile-stemcell-version
-      trigger: true
     - get: s3.fissile-linux
       trigger: true
     - get: <%= release[:name] %>-gh-release
@@ -142,11 +132,10 @@ jobs:
     - task: build
       privileged: true
       input_mapping:
-        s3.stemcell-version: s3.fissile-stemcell-version
         suse_final_release: suse-final-release-<%= release[:name] %>
       params:
         STEMCELL_REPOSITORY: <%= stemcell_repository %>
-        STEMCELL_VERSIONED_FILE: <%= stemcell_version_file %>
+        STEMCELL_VERSION: <%= stemcell_version %>
         REGISTRY_NAME: <%= registry_name %>
         REGISTRY_ORG: <%= registry_org %>
         REGISTRY_USER: <%= registry_user %>

--- a/kubecf-build-pipelines/buildpacks/tasks/build.sh
+++ b/kubecf-build-pipelines/buildpacks/tasks/build.sh
@@ -22,8 +22,7 @@ echo "${REGISTRY_PASS}" | docker login "${REGISTRY_NAME}" --username "${REGISTRY
 tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
 
 # Pull the stemcell image.
-stemcell_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}")"
-stemcell_image="${STEMCELL_REPOSITORY}:${stemcell_version}"
+stemcell_image="${STEMCELL_REPOSITORY}:${STEMCELL_VERSION}"
 docker pull "${stemcell_image}"
 
 # Build the releases.

--- a/kubecf-build-pipelines/buildpacks/tasks/build.yml
+++ b/kubecf-build-pipelines/buildpacks/tasks/build.yml
@@ -8,14 +8,13 @@ image_resource:
 inputs:
 - name: ci
 - name: build-image-resource
-- name: s3.stemcell-version
 - name: s3.fissile-linux
 - name: suse_final_release
 outputs:
 - name: built_image
 params:
   STEMCELL_REPOSITORY: ~
-  STEMCELL_VERSIONED_FILE: ~
+  STEMCELL_VERSION: ~
   REGISTRY_NAME: ~
   REGISTRY_ORG: ~
   REGISTRY_USER: ~

--- a/kubecf-build-pipelines/cf-deployment/config.yml
+++ b/kubecf-build-pipelines/cf-deployment/config.yml
@@ -12,9 +12,7 @@ cf-deployment-branch: master
 cf-deployment-yaml: cf-deployment/cf-deployment.yml
 fissile-linux-s3-bucket: cf-opensusefs2
 stemcell-repository: splatform/fissile-stemcell-sle
-stemcell-versions-s3-bucket: cf-operators
-stemcell-version-file: fissile-stemcell-versions/fissile-stemcell-sle15-version
-stemcell-s3-bucket-region: us-east-1
+stemcell-version: SLE_15_SP1-23.8
 registry-name: docker.io
 registry-org: *docker-cfcontainerization-org
 registry-user: *docker-cfcontainerization-username

--- a/kubecf-build-pipelines/cf-deployment/pipeline.yml.erb
+++ b/kubecf-build-pipelines/cf-deployment/pipeline.yml.erb
@@ -25,14 +25,6 @@ resources:
     bucket: <%= fissile_linux_s3_bucket %>
     private: true
     regexp: fissile/develop/fissile-(.*)\.tgz
-- name: s3.fissile-stemcell-version
-  type: s3
-  source:
-    bucket: <%= stemcell_versions_s3_bucket %>
-    region_name: <%= stemcell_s3_bucket_region %>
-    access_key_id: <%= s3_access_key %>
-    secret_access_key: <%= s3_secret_key %>
-    versioned_file: <%= stemcell_version_file %>
 
 jobs:
 <% cf_deployment_tags.each do |cf_deployment_tag| %>
@@ -42,19 +34,16 @@ jobs:
     - get: ci
     - get: build-image-resource
     - get: cf-deployment-<%= cf_deployment_tag %>
-    - get: s3.fissile-stemcell-version
-      trigger: true
     - get: s3.fissile-linux
       trigger: true
   - do:
     - task: build
       privileged: true
       input_mapping:
-        s3.stemcell-version: s3.fissile-stemcell-version
         cf-deployment: cf-deployment-<%= cf_deployment_tag %>
       params:
         STEMCELL_REPOSITORY: <%= stemcell_repository %>
-        STEMCELL_VERSIONED_FILE: <%= stemcell_version_file %>
+        STEMCELL_VERSION: <%= stemcell_version %>
         CF_DEPLOYMENT_YAML: <%= cf_deployment_yaml %>
         REGISTRY_NAME: <%= registry_name %>
         REGISTRY_ORG: <%= registry_org %>

--- a/kubecf-build-pipelines/cf-deployment/tasks/build.sh
+++ b/kubecf-build-pipelines/cf-deployment/tasks/build.sh
@@ -22,8 +22,7 @@ echo "${REGISTRY_PASS}" | docker login "${REGISTRY_NAME}" --username "${REGISTRY
 tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
 
 # Pull the stemcell image.
-stemcell_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}")"
-stemcell_image="${STEMCELL_REPOSITORY}:${stemcell_version}"
+stemcell_image="${STEMCELL_REPOSITORY}:${STEMCELL_VERSION}"
 docker pull "${stemcell_image}"
 
 # Build the releases.

--- a/kubecf-build-pipelines/cf-deployment/tasks/build.yml
+++ b/kubecf-build-pipelines/cf-deployment/tasks/build.yml
@@ -9,11 +9,10 @@ inputs:
 - name: ci
 - name: build-image-resource
 - name: cf-deployment
-- name: s3.stemcell-version
 - name: s3.fissile-linux
 params:
   STEMCELL_REPOSITORY: ~
-  STEMCELL_VERSIONED_FILE: ~
+  STEMCELL_VERSION: ~
   CF_DEPLOYMENT_YAML: ~
   REGISTRY_NAME: ~
   REGISTRY_ORG: ~

--- a/kubecf-build-pipelines/external-releases/config.yml
+++ b/kubecf-build-pipelines/external-releases/config.yml
@@ -5,9 +5,7 @@ build-image-resource-branch: master
 external-releases-yaml: kubecf-build-pipelines/external-releases/external-releases.yml
 fissile-linux-s3-bucket: cf-opensusefs2
 stemcell-repository: splatform/fissile-stemcell-sle
-stemcell-versions-s3-bucket: cf-operators
-stemcell-version-file: fissile-stemcell-versions/fissile-stemcell-sle15-version
-stemcell-s3-bucket-region: us-east-1
+stemcell-version: SLE_15_SP1-23.8
 registry-name: docker.io
 registry-org: *docker-cfcontainerization-org
 registry-user: *docker-cfcontainerization-username

--- a/kubecf-build-pipelines/external-releases/external-releases.yml
+++ b/kubecf-build-pipelines/external-releases/external-releases.yml
@@ -62,3 +62,7 @@ releases:
   url: https://s3.amazonaws.com/suse-final-releases/sync-integration-tests-release-v0.0.3.tgz
   version: v0.0.3
   sha1: d0809278e1958784722faaf69c7c6ac5ae063888
+- name: cf-acceptance-tests-release
+  url: https://s3.amazonaws.com/suse-final-releases/cf-acceptance-tests-release-0.0.10.tgz
+  version: 0.0.10
+  sha1: 9eb0d99889516aa2aa83de2f640d6a3ea44e05a3

--- a/kubecf-build-pipelines/external-releases/pipeline.yml.erb
+++ b/kubecf-build-pipelines/external-releases/pipeline.yml.erb
@@ -17,14 +17,6 @@ resources:
     bucket: <%= fissile_linux_s3_bucket %>
     private: true
     regexp: fissile/develop/fissile-(.*)\.tgz
-- name: s3.fissile-stemcell-version
-  type: s3
-  source:
-    bucket: <%= stemcell_versions_s3_bucket %>
-    region_name: <%= stemcell_s3_bucket_region %>
-    access_key_id: <%= s3_access_key %>
-    secret_access_key: <%= s3_secret_key %>
-    versioned_file: <%= stemcell_version_file %>
 - name: external-releases
   type: git
   source:
@@ -41,20 +33,16 @@ jobs:
   - in_parallel:
     - get: ci
     - get: build-image-resource
-    - get: s3.fissile-stemcell-version
-      trigger: true
     - get: s3.fissile-linux
       trigger: true
     - get: external-releases
       trigger: true
   - do:
     - task: build
-      privileged: true
-      input_mapping:
-        s3.stemcell-version: s3.fissile-stemcell-version 
+      privileged: true 
       params:
         STEMCELL_REPOSITORY: <%= stemcell_repository %>
-        STEMCELL_VERSIONED_FILE: <%= stemcell_version_file %>
+        STEMCELL_VERSION: <%= stemcell_version %>
         EXTERNAL_RELEASES_YAML: <%= external_releases_yaml %>
         REGISTRY_NAME: <%= registry_name %>
         REGISTRY_ORG: <%= registry_org %>

--- a/kubecf-build-pipelines/external-releases/tasks/build.sh
+++ b/kubecf-build-pipelines/external-releases/tasks/build.sh
@@ -22,8 +22,7 @@ echo "${REGISTRY_PASS}" | docker login "${REGISTRY_NAME}" --username "${REGISTRY
 tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
 
 # Pull the stemcell image.
-stemcell_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}")"
-stemcell_image="${STEMCELL_REPOSITORY}:${stemcell_version}"
+stemcell_image="${STEMCELL_REPOSITORY}:${STEMCELL_VERSION}"
 docker pull "${stemcell_image}"
 
 # Build the releases.

--- a/kubecf-build-pipelines/external-releases/tasks/build.yml
+++ b/kubecf-build-pipelines/external-releases/tasks/build.yml
@@ -8,12 +8,11 @@ image_resource:
 inputs:
 - name: ci
 - name: build-image-resource
-- name: s3.stemcell-version
 - name: s3.fissile-linux
 - name: external-releases
 params:
   STEMCELL_REPOSITORY: ~
-  STEMCELL_VERSIONED_FILE: ~
+  STEMCELL_VERSION: ~
   EXTERNAL_RELEASES_YAML: ~
   REGISTRY_NAME: ~
   REGISTRY_ORG: ~


### PR DESCRIPTION
Currently in order to build images only the latest stemcell version
is retrieved and used from the fissile s3 bucket. This change makes the
version configurable in config.yaml file. Proper bump procedure must be
followed moving ahead before bumping stemcell version.