### PR TITLE
fix: chop off pxc from the cf-deployment releases

### DIFF
--- a/kubecf-build-pipelines/cf-deployment/tasks/build.sh
+++ b/kubecf-build-pipelines/cf-deployment/tasks/build.sh
@@ -28,4 +28,4 @@ docker pull "${stemcell_image}"
 
 # Build the releases.
 tasks_dir="$(dirname $0)"
-bash <(yq -r ".manifest_version as \$cf_version | .releases[] | \"source ${tasks_dir}/build_release.sh; build_release \\(\$cf_version|@sh) '${REGISTRY_NAME}' '${REGISTRY_ORG}' '${stemcell_image}' \\(.name|@sh) \\(.url|@sh) \\(.version|@sh) \\(.sha1|@sh)\"" "${CF_DEPLOYMENT_YAML}")
+bash <(yq -r ".manifest_version as \$cf_version | .releases[] | select(.name != \"pxc\") | \"source ${tasks_dir}/build_release.sh; build_release \\(\$cf_version|@sh) '${REGISTRY_NAME}' '${REGISTRY_ORG}' '${stemcell_image}' \\(.name|@sh) \\(.url|@sh) \\(.version|@sh) \\(.sha1|@sh)\"" "${CF_DEPLOYMENT_YAML}")


### PR DESCRIPTION
Removing pxc BOSH release as it fails to build: https://concourse.suse.de/teams/main/pipelines/kubecf-cf-deployment/jobs/build-v12.36.0/builds/5.