### PR TITLE
Add missing version field

### DIFF
--- a/kubecf-build-pipelines/buildpacks/tasks/create_pr.sh
+++ b/kubecf-build-pipelines/buildpacks/tasks/create_pr.sh
@@ -50,6 +50,7 @@ with open("${KUBECF_VALUES}") as fp:
     values = yaml.load(fp)
 
 values['releases']["${BUILDPACK_NAME}"]['url'] = NEW_URL
+values['releases']["${BUILDPACK_NAME}"]['version'] = NEW_VERSION
 values['releases']["${BUILDPACK_NAME}"]['stemcell']['os'] = NEW_STEMCELL_OS
 values['releases']["${BUILDPACK_NAME}"]['stemcell']['version'] = NEW_STEMCELL_VERSION
 values['releases']["${BUILDPACK_NAME}"]['file'] = get_new_filename()


### PR DESCRIPTION
This is breaking kubecf build as the `version` field is used in order to build the final URL to be pulled.
See: https://github.com/cloudfoundry-incubator/kubecf/pull/546