### PR TITLE
Bump CATS to 0.0.16

### DIFF
--- a/kubecf-build-pipelines/external-releases/external-releases.yml
+++ b/kubecf-build-pipelines/external-releases/external-releases.yml
@@ -16,9 +16,9 @@ releases:
   version: 10.100
   sha1: a60edb70a1d7d3506dd7018a7e042a791031e5bb
 - name: cf-acceptance-tests-release
-  url: https://s3.amazonaws.com/suse-final-releases/cf-acceptance-tests-release-0.0.15.tgz
-  version: 0.0.15
-  sha1: c2d892f5c5ba04c457c4662158036aafc94ecf86
+  url: https://s3.amazonaws.com/suse-final-releases/cf-acceptance-tests-release-0.0.16.tgz
+  version: 0.0.16
+  sha1: 0788ac739d51b8b5995cbcbf35567cf49ef64595
 - name: postgres
   url: https://bosh.io/d/github.com/cloudfoundry/postgres-release?v=39
   version: 39


### PR DESCRIPTION
Actually switch the cf-acceptance-tests to use the correct branch for cf-deployment 13.9.0.